### PR TITLE
Add vpc-policy for ENI connection

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -160,6 +160,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: report-api
+      Policies:
+        - VPCAccessPolicy: { }
       Handler: no.sikt.nva.data.report.api.fetch.FetchDataReport::handleRequest
       Role: !GetAtt LambdaRole.Arn
       Timeout: 600


### PR DESCRIPTION
In order to connect to Neptune, it appears that this is necessary:

- Add policy for VPC connection