### PR TITLE
Np 45931 distinguish update types

### DIFF
--- a/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/EventType.java
+++ b/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/EventType.java
@@ -1,0 +1,21 @@
+package no.sikt.nva.data.report.api.etl;
+
+import java.util.stream.Stream;
+
+public enum EventType {
+    UPSERT("PutObject"),
+    DELETE("DeleteObject");
+
+    private final String value;
+
+    EventType(String value) {
+        this.value = value;
+    }
+
+    public static EventType parse(String candidate) {
+        return Stream.of(values())
+                   .filter(eventType -> eventType.value.equals(candidate))
+                   .findFirst()
+                   .orElseThrow(() -> new IllegalArgumentException("Unknown event type: " + candidate));
+    }
+}

--- a/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/PersistedResourceEvent.java
+++ b/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/PersistedResourceEvent.java
@@ -1,13 +1,13 @@
 package no.sikt.nva.data.report.api.etl;
 
-public record PersistedResourceEvent(String bucketName, String key, String operation) {
+public record PersistedResourceEvent(String bucketName, String key, String eventType) {
 
     @Override
     public String toString() {
         return "PersistedResourceEvent{"
                + "bucketName='" + bucketName + '\''
                + ", key='" + key + '\''
-               + ", operation='" + operation + '\''
+               + ", eventType='" + eventType + '\''
                + '}';
     }
 }

--- a/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoader.java
+++ b/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoader.java
@@ -32,16 +32,16 @@ public class SingleObjectDataLoader implements RequestHandler<PersistedResourceE
         getEventType(input).ifPresentOrElse(this::logEventType, () -> logUnknownEventType(input.eventType()));
     }
 
+    private void logEventType(EventType eventType) {
+        LOGGER.info("Event type: {}", eventType);
+    }
+
     private void logFolderName(UnixPath folder) {
         LOGGER.info("Object folder: {}", folder);
     }
 
     private Optional<EventType> getEventType(PersistedResourceEvent input) {
         return attempt(() -> EventType.parse(input.eventType())).toOptional();
-    }
-
-    private void logEventType(EventType eventType) {
-        LOGGER.info("Event type: {}", eventType);
     }
 
     private void logUnknownEventType(String eventType) {

--- a/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoader.java
+++ b/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoader.java
@@ -18,6 +18,7 @@ public class SingleObjectDataLoader implements RequestHandler<PersistedResourceE
     public Void handleRequest(PersistedResourceEvent input, Context context) {
         LOGGER.info("Handling request with input: {}", input.toString());
         UnixPath.of(input.key()).getParent().ifPresentOrElse(this::logFolderName, this::logNoParentFolder);
+        LOGGER.info("Operation: {}", input.operation());
         return null;
     }
 

--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
@@ -53,13 +53,22 @@ class SingleObjectDataLoaderTest {
         assertTrue(logAppender.getMessages().contains("No parent folder"));
     }
 
-    @ParameterizedTest(name = "Should extract and log operation type {0}")
-    @ValueSource(strings = {"PubObject", "DeleteObject"})
-    void shouldExtractAndLogOperationType(String operation) {
+    @ParameterizedTest(name = "Should extract and log eventType type {0}")
+    @ValueSource(strings = {"PutObject", "DeleteObject"})
+    void shouldExtractAndLogOperationType(String eventType) {
         var key = UnixPath.of(RESOURCES_FOLDER, randomString()).toString();
-        var event = new PersistedResourceEvent(BUCKET_NAME, key, operation);
+        var event = new PersistedResourceEvent(BUCKET_NAME, key, eventType);
         final var logAppender = LogUtils.getTestingAppenderForRootLogger();
         handler.handleRequest(event, context);
-        assertTrue(logAppender.getMessages().contains("Operation: " + operation));
+        assertTrue(logAppender.getMessages().contains("Event type: " + EventType.parse(eventType)));
+    }
+
+    @Test
+    void shouldLogUnknownEventTypeIfEventTypeIsUnknown() {
+        var key = UnixPath.of(RESOURCES_FOLDER, randomString()).toString();
+        var event = new PersistedResourceEvent(BUCKET_NAME, key, randomString());
+        final var logAppender = LogUtils.getTestingAppenderForRootLogger();
+        handler.handleRequest(event, context);
+        assertTrue(logAppender.getMessages().contains("Unknown event type: " + event.eventType()));
     }
 }

--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
@@ -34,7 +34,7 @@ class SingleObjectDataLoaderTest {
         assertTrue(logAppender.getMessages().contains("Initializing DataLoader"));
     }
 
-    @ParameterizedTest(name = "should extract and log folderName {0}")
+    @ParameterizedTest(name = "Should extract and log folderName {0}")
     @ValueSource(strings = {RESOURCES_FOLDER, NVI_CANDIDATES_FOLDER})
     void shouldExtractAndLogObjectParentFolder(String folderName) {
         var key = UnixPath.of(folderName, randomString()).toString();
@@ -51,5 +51,15 @@ class SingleObjectDataLoaderTest {
         var event = new PersistedResourceEvent(BUCKET_NAME, key, SOME_OPERATION);
         handler.handleRequest(event, context);
         assertTrue(logAppender.getMessages().contains("No parent folder"));
+    }
+
+    @ParameterizedTest(name = "Should extract and log operation type {0}")
+    @ValueSource(strings = {"PubObject", "DeleteObject"})
+    void shouldExtractAndLogOperationType(String operation) {
+        var key = UnixPath.of(RESOURCES_FOLDER, randomString()).toString();
+        var event = new PersistedResourceEvent(BUCKET_NAME, key, operation);
+        final var logAppender = LogUtils.getTestingAppenderForRootLogger();
+        handler.handleRequest(event, context);
+        assertTrue(logAppender.getMessages().contains("Operation: " + operation));
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -244,8 +244,8 @@ Resources:
             InputPathsMap:
               bucketName: "$.detail.bucket.name"
               key: "$.detail.object.key"
-              operation: "$.detail.reason"
-            InputTemplate: '{"bucketName": <bucketName>, "key": <key>, "operation": <operation>}'
+              eventType: "$.detail.reason"
+            InputTemplate: '{"bucketName": <bucketName>, "key": <key>, "eventType": <eventType>}'
           DeadLetterConfig:
             Arn: !GetAtt DataReportPersistedResourceDLQ.Arn
           RetryPolicy:


### PR DESCRIPTION
Jira task: [Distinguish between new, updates (potentially) and deletions](https://unit.atlassian.net/browse/NP-45931)

Not able to distinguish between new/create and update for s3 events, see links:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
[AWS Lambda using S3 Trigger: Distinguish between create and update](https://stackoverflow.com/questions/50866658/aws-lambda-using-s3-trigger-distinguish-between-create-and-update)
Discussed this with @brinxmat, we can handle this by doing a sparql ASK before inserts/updates.