### PR TITLE
Use endpoint for read/write

### DIFF
--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/SingleObjectDataLoaderTest.java
@@ -64,7 +64,7 @@ class SingleObjectDataLoaderTest {
         server = FusekiTestingServer.init(dataSet, GSP_ENDPOINT);
         var url = server.serverURL();
         var queryPath = new Environment().readEnv("QUERY_PATH");
-        dbConnection = new GraphStoreProtocolConnection(url, url, queryPath);
+        dbConnection = new GraphStoreProtocolConnection(url, queryPath);
         var fakeS3Client = new FakeS3Client();
         s3Driver = new S3Driver(fakeS3Client, BUCKET_NAME);
         storageReader = new S3StorageReader(fakeS3Client, BUCKET_NAME);

--- a/data-report-commons/src/main/java/commons/db/GraphStoreProtocolConnection.java
+++ b/data-report-commons/src/main/java/commons/db/GraphStoreProtocolConnection.java
@@ -28,8 +28,7 @@ public class GraphStoreProtocolConnection implements DatabaseConnection {
                                                                     + " SELECT";
     private static final String GSP_ENDPOINT = "gsp/";
     private static final String SPARQL_PATH = "sparql";
-    private final String writeEndpoint;
-    private final String readEndpoint;
+    private final String endpoint;
     private final String queryPath;
 
     @JacocoGenerated
@@ -39,14 +38,13 @@ public class GraphStoreProtocolConnection implements DatabaseConnection {
 
     @JacocoGenerated
     private GraphStoreProtocolConnection(Environment environment) {
-        this(constructEndPointUri(environment.readEnv("NEPTUNE_WRITE_ENDPOINT"), environment.readEnv("NEPTUNE_PORT")),
-             constructEndPointUri(environment.readEnv("NEPTUNE_READ_ENDPOINT"), environment.readEnv("NEPTUNE_PORT")),
+        this(constructEndPointUri(environment.readEnv("NEPTUNE_ENDPOINT"),
+                                  environment.readEnv("NEPTUNE_PORT")),
              environment.readEnv("QUERY_PATH"));
     }
 
-    public GraphStoreProtocolConnection(String writeEndpoint, String readEndpoint, String queryPath) {
-        this.writeEndpoint = writeEndpoint;
-        this.readEndpoint = readEndpoint;
+    public GraphStoreProtocolConnection(String endpoint, String queryPath) {
+        this.endpoint = endpoint;
         this.queryPath = queryPath;
     }
 
@@ -54,7 +52,7 @@ public class GraphStoreProtocolConnection implements DatabaseConnection {
     public void logConnection() {
         try (var connection = configureReadConnection()) {
             var model = connection.fetch();
-            LOGGER.info("Connection to {} successful, model size: {}", writeEndpoint, model.size());
+            LOGGER.info("Connection to {} successful, model size: {}", endpoint, model.size());
         }
     }
 
@@ -111,13 +109,13 @@ public class GraphStoreProtocolConnection implements DatabaseConnection {
     }
 
     private RDFConnection configureReadConnection() {
-        return getRdfConnectionRemoteBuilder(readEndpoint)
+        return getRdfConnectionRemoteBuilder(endpoint)
                    .queryEndpoint(queryPath)
                    .build();
     }
 
     private RDFConnection configureWriteConnection() {
-        return getRdfConnectionRemoteBuilder(writeEndpoint)
+        return getRdfConnectionRemoteBuilder(endpoint)
                    .build();
     }
 

--- a/data-report-commons/src/test/java/commons/db/GraphStoreProtocolConnectionTest.java
+++ b/data-report-commons/src/test/java/commons/db/GraphStoreProtocolConnectionTest.java
@@ -37,7 +37,7 @@ class GraphStoreProtocolConnectionTest {
         var dataSet = DatasetFactory.createTxnMem();
         server = FusekiTestingServer.init(dataSet, GSP_ENDPOINT);
         var url = server.serverURL();
-        dbConnection = new GraphStoreProtocolConnection(url, url, new Environment().readEnv("QUERY_PATH"));
+        dbConnection = new GraphStoreProtocolConnection(url, new Environment().readEnv("QUERY_PATH"));
     }
 
     @AfterAll

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
@@ -59,7 +59,7 @@ class FetchDataReportTest {
         server = FusekiTestingServer.init(dataSet, GSP_ENDPOINT);
         var url = server.serverURL();
         var queryPath = new Environment().readEnv("QUERY_PATH");
-        databaseConnection = new GraphStoreProtocolConnection(url, url, queryPath);
+        databaseConnection = new GraphStoreProtocolConnection(url, queryPath);
     }
 
     @AfterAll

--- a/template.yaml
+++ b/template.yaml
@@ -74,8 +74,7 @@ Globals:
         - !Ref LambdaSubnet2
     Environment:
       Variables:
-        NEPTUNE_WRITE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
-        NEPTUNE_READ_ENDPOINT: !GetAtt NeptuneCluster.ReadEndpoint
+        NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
         API_HOST: !Ref ApiDomain
         QUERY_PATH: "query"
         NEPTUNE_PORT: 8182


### PR DESCRIPTION
Looking at [the documentation](https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html#feature-overview-cluster-endpoints), we are not doing things in the right way.

- Use NeptuneCluster.Endpoint rather than attempting to split out read operations.