### PR TITLE
Add triple-to-nquad conversion

### DIFF
--- a/bulk-load/build.gradle
+++ b/bulk-load/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'nva.data.report.api.java-conventions'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation libs.bundles.jena
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/Nquads.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/Nquads.java
@@ -1,0 +1,47 @@
+package no.sikt.nva.data.report.api.etl;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.nio.file.Files;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+
+public class Nquads {
+
+    private static final String PATH_SEPARATOR = "/";
+    private final DatasetGraph graph;
+
+    private Nquads(DatasetGraph graph) {
+        this.graph = graph;
+    }
+
+    public static Nquads transform(File file, URI graphName) throws IOException {
+        var model = loadModel(file);
+        var node = model.createResource(graphName.toString() + PATH_SEPARATOR + file.getName()).asNode();
+        var graph = DatasetGraphFactory.createTxnMem();
+        graph.addGraph(node, model.getGraph());
+        return new Nquads(graph);
+    }
+
+    @Override
+    public String toString() {
+        var stringWriter = new StringWriter();
+        RDFDataMgr.write(stringWriter, graph, RDFFormat.NQUADS);
+        return stringWriter.toString();
+    }
+
+    private static Model loadModel(File file) throws IOException {
+        var data = new ByteArrayInputStream(Files.readAllBytes(file.toPath()));
+        var model = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(model, data, Lang.NTRIPLES);
+        return model;
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/Nquads.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/Nquads.java
@@ -14,7 +14,7 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 
-public class Nquads {
+public final class Nquads {
 
     private static final String PATH_SEPARATOR = "/";
     private final DatasetGraph graph;

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/NquadsTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/NquadsTest.java
@@ -1,0 +1,42 @@
+package no.sikt.nva.data.report.api.etl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NquadsTest {
+
+    public static final URI GRAPH_BASE = URI.create("https://example.org/nva");
+    @TempDir
+    private File directory;
+
+    @Test
+    void shouldTransformInputToNquads() throws IOException {
+        var file = createFile();
+        var actual = Nquads.transform(file, GRAPH_BASE);
+        var expected = createExpected(file);
+        assertEquals(expected, actual.toString());
+    }
+
+    private static String createExpected(File file) throws IOException {
+        return Files.readAllLines(file.toPath()).stream()
+                   .map(line -> line.replaceAll(" \\.$", ""))
+                   .map(line -> line + " <" + GRAPH_BASE + "/" + file.getName() + "> .")
+                   .collect(Collectors.joining(System.lineSeparator()))
+               + System.lineSeparator();
+    }
+
+    private File createFile() throws IOException {
+        var data = """
+            <https://example.org/s> <https://example.org/p> <https://example.org/o> .
+            """;
+        var file = new File(directory, "expectedFilename.gz");
+        Files.writeString(file.toPath(), data);
+        return file;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,5 @@ include 'data-loading'
 include 'data-report-commons'
 include 'testing-utils'
 include 'database-tools'
+include 'bulk-load'
 


### PR DESCRIPTION
- First step to create nquads to be loaded via AWS Neptune's bulk load functionality
- Convert a file containing triples to a set of nquads where the graph name includes the file name