### PR TITLE
Add bulk loader

### DIFF
--- a/bulk-load/build.gradle
+++ b/bulk-load/build.gradle
@@ -8,4 +8,21 @@ repositories {
 
 dependencies {
     implementation libs.bundles.jena
+    implementation libs.nva.s3
+    implementation libs.nva.commons.core
+    implementation libs.aws.sdk2.lambda.events
+    implementation libs.aws.lambda.java.core
+    implementation libs.bundles.logging
+
+    testImplementation('com.github.bibsysdev:nvatestutils:1.36.12') {
+        exclude group: 'org.wiremock', module: 'wiremock'
+    }
+
+    test {
+        environment("NEPTUNE_ENDPOINT", "localhost")
+        environment("NEPTUNE_PORT", "8182")
+        environment("LOADER_IAM_ROLE", "aim:role:loader")
+        environment("AWS_REGION", "eu-west-1")
+        environment("LOADER_BUCKET", "s3://someBucket")
+    }
 }

--- a/bulk-load/build.gradle
+++ b/bulk-load/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation libs.bundles.jena
     implementation libs.nva.s3
     implementation libs.nva.commons.core
+    implementation libs.nva.json
     implementation libs.aws.sdk2.lambda.events
     implementation libs.aws.lambda.java.core
     implementation libs.bundles.logging

--- a/bulk-load/build.gradle
+++ b/bulk-load/build.gradle
@@ -22,7 +22,7 @@ dependencies {
         environment("NEPTUNE_ENDPOINT", "localhost")
         environment("NEPTUNE_PORT", "8182")
         environment("LOADER_IAM_ROLE", "aim:role:loader")
-        environment("AWS_REGION", "eu-west-1")
+        environment("AWS_REGION_NAME", "eu-west-1")
         environment("LOADER_BUCKET", "s3://someBucket")
     }
 }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -79,6 +79,6 @@ public class BulkLoadHandler implements RequestStreamHandler {
     }
 
     private static URI getLoaderSpecSource(Environment environment) {
-        return URI.create(environment.readEnv(LOADER_BUCKET));
+        return URI.create(environment.readEnv(LOADER_BUCKET) + "/files");
     }
 }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -10,8 +10,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
-import no.sikt.nva.data.report.api.etl.loader.LoaderSpec.Builder;
 import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +28,11 @@ public class BulkLoadHandler implements RequestStreamHandler {
     public static final String LOADER_BUCKET = "LOADER_BUCKET";
     public static final int HTTP_OK = 200;
     private final HttpClient httpClient;
+
+    @JacocoGenerated
+    public BulkLoadHandler() {
+        this.httpClient = HttpClient.newHttpClient();
+    }
 
     public BulkLoadHandler(HttpClient httpClient) {
         this.httpClient = httpClient;
@@ -60,7 +65,7 @@ public class BulkLoadHandler implements RequestStreamHandler {
     }
 
     private static String createLoaderSpec(Environment environment) {
-        return new Builder()
+        return new LoaderSpec.Builder()
                    .withSource(getLoaderSpecSource(environment))
                    .withFormat(Format.NQUADS)
                    .withFailOnError(true)

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
-import static java.util.Objects.isNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
@@ -14,7 +13,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.ioutils.IoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -45,13 +45,12 @@ public class BulkLoadHandler implements RequestStreamHandler {
 
     @Override
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) {
-        var input = IoUtils.streamToString(inputStream);
-        if (isNull(input) || input.isEmpty()) {
+        var errorLogRequest = attempt(() -> JsonUtils.dtoObjectMapper
+                                                .readValue(inputStream, ErrorLogRequest.class));
+        if (errorLogRequest.isFailure()) {
             executeLoadOperation();
         } else {
-            var errorLogRequest = attempt(() -> JsonUtils.dtoObjectMapper
-                                      .readValue(input, ErrorLogRequest.class)).orElseThrow();
-            executeLogRequest(errorLogRequest);
+            executeLogRequest(errorLogRequest.orElseThrow());
         }
     }
 

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -68,9 +68,7 @@ public class BulkLoadHandler implements RequestStreamHandler {
     private void executeLogRequest(ErrorLogRequest errorLogRequest) {
         var response = attempt(() -> httpClient.send(createLogRequest(errorLogRequest),
                                                      BodyHandlers.ofString())).orElseThrow();
-        var responseBody = attempt(() -> JsonUtils.dtoObjectMapper
-                                             .writeValueAsString(response.body()))
-                               .orElseThrow();
+        var responseBody = response.body();
         if (response.statusCode() == HTTP_OK) {
             logger.info("Logs for loadId {}: {}", errorLogRequest.loadId(), responseBody);
         } else {
@@ -99,14 +97,12 @@ public class BulkLoadHandler implements RequestStreamHandler {
     }
 
     private URI createLogRequestUri(Environment environment, ErrorLogRequest errorLogRequest) {
-        var uri = URI.create(String.format(ERROR_LOG_URI_TEMPLATE,
+        return URI.create(String.format(ERROR_LOG_URI_TEMPLATE,
                                         environment.readEnv(NEPTUNE_ENDPOINT),
                                         environment.readEnv(NEPTUNE_PORT),
                                         errorLogRequest.loadId().toString(),
                                         errorLogRequest.page(),
                                         errorLogRequest.errorsPerPage()));
-        logger.info(uri.toString());
-        return uri;
     }
 
     private static URI createUri(Environment environment) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
+import static java.util.Objects.isNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
@@ -44,11 +45,12 @@ public class BulkLoadHandler implements RequestStreamHandler {
     @Override
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) {
         var errorLogRequest = attempt(() -> JsonUtils.dtoObjectMapper
-                                                .readValue(inputStream, ErrorLogRequest.class));
-        if (errorLogRequest.isFailure()) {
+                                                .readValue(inputStream, ErrorLogRequest.class))
+                                  .orElseThrow();
+        if (isNull(errorLogRequest.loadId())) {
             executeLoadOperation();
         } else {
-            executeLogRequest(errorLogRequest.orElseThrow());
+            executeLogRequest(errorLogRequest);
         }
     }
 

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -68,14 +68,15 @@ public class BulkLoadHandler implements RequestStreamHandler {
     private void executeLogRequest(ErrorLogRequest errorLogRequest) {
         var response = attempt(() -> httpClient.send(createLogRequest(errorLogRequest),
                                                      BodyHandlers.ofString())).orElseThrow();
-        var responseBody = response.body();
+        var responseBody = attempt(() -> JsonUtils.dtoObjectMapper
+                                             .writeValueAsString(response.body()))
+                               .orElseThrow();
         if (response.statusCode() == HTTP_OK) {
             logger.info("Logs for loadId {}: {}", errorLogRequest.loadId(), responseBody);
         } else {
             logger.error("Log request failed for loadId {}: {}",
                          errorLogRequest.loadId(),
-                         attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(responseBody))
-                             .orElseThrow());
+                         responseBody);
         }
     }
 

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -92,7 +92,7 @@ public class BulkLoadHandler implements RequestStreamHandler {
     private HttpRequest createLogRequest(ErrorLogRequest errorLogRequest) {
         var environment = new Environment();
         return HttpRequest.newBuilder()
-                   .POST(BodyPublishers.ofString(createLoaderSpec(environment)))
+                   .GET()
                    .header(CONTENT_TYPE, APPLICATION_JSON)
                    .uri(createLogRequestUri(environment, errorLogRequest))
                    .build();

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -24,7 +24,7 @@ public class BulkLoadHandler implements RequestStreamHandler {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String APPLICATION_JSON = "application/json";
     public static final String LOADER_IAM_ROLE = "LOADER_IAM_ROLE";
-    public static final String AWS_REGION = "AWS_REGION";
+    public static final String AWS_REGION = "AWS_REGION_NAME";
     public static final String LOADER_BUCKET = "LOADER_BUCKET";
     public static final int HTTP_OK = 200;
     private final HttpClient httpClient;

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -1,0 +1,79 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import no.sikt.nva.data.report.api.etl.loader.LoaderSpec.Builder;
+import nva.commons.core.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BulkLoadHandler implements RequestStreamHandler {
+
+    public static final Logger logger = LoggerFactory.getLogger(BulkLoadHandler.class);
+    private static final String URI_TEMPLATE = "https://%s:%s/loader";
+    public static final String NEPTUNE_ENDPOINT = "NEPTUNE_ENDPOINT";
+    public static final String NEPTUNE_PORT = "NEPTUNE_PORT";
+    public static final String CONTENT_TYPE = "Content-Type";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String LOADER_IAM_ROLE = "LOADER_IAM_ROLE";
+    public static final String AWS_REGION = "AWS_REGION";
+    public static final String LOADER_BUCKET = "LOADER_BUCKET";
+    public static final int HTTP_OK = 200;
+    private final HttpClient httpClient;
+
+    public BulkLoadHandler(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) {
+        var response = attempt(() -> httpClient.send(createRequest(), BodyHandlers.ofString())).orElseThrow();
+        var responseBody = response.body();
+        if (response.statusCode() == HTTP_OK) {
+            logger.info("Successfully initiated load: {}", responseBody);
+        } else {
+            logger.error("Loading failed: {}", responseBody);
+        }
+    }
+
+    private static HttpRequest createRequest() {
+        var environment = new Environment();
+        return HttpRequest.newBuilder()
+                   .POST(BodyPublishers.ofString(createLoaderSpec(environment)))
+                   .header(CONTENT_TYPE, APPLICATION_JSON)
+                   .uri(createUri(environment))
+                   .build();
+    }
+
+    private static URI createUri(Environment environment) {
+        return URI.create(String.format(URI_TEMPLATE,
+                                        environment.readEnv(NEPTUNE_ENDPOINT),
+                                        environment.readEnv(NEPTUNE_PORT)));
+    }
+
+    private static String createLoaderSpec(Environment environment) {
+        return new Builder()
+                   .withSource(getLoaderSpecSource(environment))
+                   .withFormat(Format.NQUADS)
+                   .withFailOnError(true)
+                   .withParallelism(Parallelism.MEDIUM)
+                   .withIamRoleArn(environment.readEnv(LOADER_IAM_ROLE))
+                   .withQueueRequest(true)
+                   .withRegion(environment.readEnv(AWS_REGION))
+                   .withUpdateSingleCardinalityProperties(false)
+                   .build()
+                   .toString();
+    }
+
+    private static URI getLoaderSpecSource(Environment environment) {
+        return URI.create(environment.readEnv(LOADER_BUCKET));
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -99,12 +99,14 @@ public class BulkLoadHandler implements RequestStreamHandler {
     }
 
     private URI createLogRequestUri(Environment environment, ErrorLogRequest errorLogRequest) {
-        return URI.create(String.format(ERROR_LOG_URI_TEMPLATE,
+        var uri = URI.create(String.format(ERROR_LOG_URI_TEMPLATE,
                                         environment.readEnv(NEPTUNE_ENDPOINT),
                                         environment.readEnv(NEPTUNE_PORT),
                                         errorLogRequest.loadId().toString(),
                                         errorLogRequest.page(),
                                         errorLogRequest.errorsPerPage()));
+        logger.info(uri.toString());
+        return uri;
     }
 
     private static URI createUri(Environment environment) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.ioutils.IoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,12 @@ public class BulkLoadHandler implements RequestStreamHandler {
 
     @Override
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) {
-        if (isNull(inputStream)) {
+        var input = IoUtils.streamToString(inputStream);
+        if (isNull(input) || input.isEmpty()) {
             executeLoadOperation();
         } else {
             var errorLogRequest = attempt(() -> JsonUtils.dtoObjectMapper
-                                      .readValue(inputStream, ErrorLogRequest.class)).orElseThrow();
+                                      .readValue(input, ErrorLogRequest.class)).orElseThrow();
             executeLogRequest(errorLogRequest);
         }
     }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -74,7 +74,8 @@ public class BulkLoadHandler implements RequestStreamHandler {
         } else {
             logger.error("Log request failed for loadId {}: {}",
                          errorLogRequest.loadId(),
-                         responseBody);
+                         attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(responseBody))
+                             .orElseThrow());
         }
     }
 

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
@@ -3,7 +3,6 @@ package no.sikt.nva.data.report.api.etl.loader;
 import static java.util.Objects.nonNull;
 import java.net.URI;
 import java.util.UUID;
-import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 
 public record ErrorLogRequest(UUID loadId, Integer page, Integer errorsPerPage) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
@@ -1,0 +1,17 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+import static java.util.Objects.nonNull;
+import java.util.UUID;
+
+public record ErrorLogRequest(UUID loadId, Integer page, Integer errorsPerPage) {
+
+    @Override
+    public Integer page() {
+        return nonNull(page) ? page : 1;
+    }
+
+    @Override
+    public Integer errorsPerPage() {
+        return nonNull(errorsPerPage) ? errorsPerPage : 3;
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/ErrorLogRequest.java
@@ -1,7 +1,10 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
 import static java.util.Objects.nonNull;
+import java.net.URI;
 import java.util.UUID;
+import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
 
 public record ErrorLogRequest(UUID loadId, Integer page, Integer errorsPerPage) {
 
@@ -13,5 +16,16 @@ public record ErrorLogRequest(UUID loadId, Integer page, Integer errorsPerPage) 
     @Override
     public Integer errorsPerPage() {
         return nonNull(errorsPerPage) ? errorsPerPage : 3;
+    }
+
+    public URI uri(String endpoint, int port) {
+        return UriWrapper.fromHost(endpoint, port)
+                   .addChild("loader")
+                   .addChild(loadId().toString())
+                   .addQueryParameter("details", "true")
+                   .addQueryParameter("errors", "true")
+                   .addQueryParameter("page", String.valueOf(page()))
+                   .addQueryParameter("errorsPerPage", String.valueOf(errorsPerPage()))
+                   .getUri();
     }
 }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/Format.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/Format.java
@@ -1,0 +1,17 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+public enum Format {
+    NQUADS("nquads");
+
+    private final String string;
+
+    Format(String string) {
+
+        this.string = string;
+    }
+
+    @Override
+    public String toString() {
+        return string;
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
@@ -1,0 +1,98 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+import java.net.URI;
+import java.util.Locale;
+
+public record LoaderSpec(URI source,
+                         Format format,
+                         String iamRoleArn,
+                         String region,
+                         boolean failOnError,
+                         Parallelism parallelism,
+                         boolean updateSingleCardinalityProperties,
+                         boolean queueRequest) {
+
+    @Override
+    public String toString() {
+        return String.format("""
+                                 {
+                                 "source": "%s",
+                                 "format": "%s",
+                                 "iamRoleArn": "%s",
+                                 "region": "%s",
+                                 "failOnError": "%s",
+                                 "parallelism": "%s",
+                                 "updateSingleCardinalityProperties": "%s",
+                                 "queueRequest": "%s",
+                                 "dependencies": [],
+                                 }""", source, format.toString(), iamRoleArn, region,
+                             booleanString(failOnError), parallelism.toString(),
+                             booleanString(updateSingleCardinalityProperties),
+                             booleanString(queueRequest));
+    }
+
+    private String booleanString(boolean value) {
+        var string = String.valueOf(value);
+        return string.toUpperCase(Locale.ROOT);
+    }
+
+    public static final class Builder {
+
+        private URI source;
+        private Format format;
+        private String iamRoleArn;
+        private String region;
+        private boolean failOnError;
+        private Parallelism parallelism;
+        private boolean updateSingleCardinalityProperties;
+        private boolean queueRequest;
+        public Builder() {
+            // Default constructor.
+        }
+
+        public Builder withSource(URI source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder withFormat(Format format) {
+            this.format = format;
+            return this;
+        }
+
+        public Builder withIamRoleArn(String iamRoleArn) {
+            this.iamRoleArn = iamRoleArn;
+            return this;
+        }
+
+        public Builder withRegion(String region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder withFailOnError(boolean failOnError) {
+            this.failOnError = failOnError;
+            return this;
+        }
+
+        public Builder withParallelism(Parallelism parallelism) {
+            this.parallelism = parallelism;
+            return this;
+        }
+
+        public Builder withUpdateSingleCardinalityProperties(boolean updateSingleCardinalityProperties) {
+            this.updateSingleCardinalityProperties = updateSingleCardinalityProperties;
+            return this;
+        }
+
+        public Builder withQueueRequest(boolean queueRequest) {
+            this.queueRequest = queueRequest;
+            return this;
+        }
+
+        public LoaderSpec build() {
+            return new LoaderSpec(source, format, iamRoleArn, region, failOnError, parallelism,
+                                  updateSingleCardinalityProperties, queueRequest);
+        }
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
@@ -46,6 +46,7 @@ public record LoaderSpec(URI source,
         private Parallelism parallelism;
         private boolean updateSingleCardinalityProperties;
         private boolean queueRequest;
+
         public Builder() {
             // Default constructor.
         }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/LoaderSpec.java
@@ -15,8 +15,7 @@ public record LoaderSpec(URI source,
     @Override
     public String toString() {
         return String.format("""
-                                 {
-                                 "source": "%s",
+                                 {"source": "%s",
                                  "format": "%s",
                                  "iamRoleArn": "%s",
                                  "region": "%s",
@@ -24,8 +23,9 @@ public record LoaderSpec(URI source,
                                  "parallelism": "%s",
                                  "updateSingleCardinalityProperties": "%s",
                                  "queueRequest": "%s",
-                                 "dependencies": [],
-                                 }""", source, format.toString(), iamRoleArn, region,
+                                 "dependencies": []
+                                 }
+                                 """, source, format.toString(), iamRoleArn, region,
                              booleanString(failOnError), parallelism.toString(),
                              booleanString(updateSingleCardinalityProperties),
                              booleanString(queueRequest));

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/Parallelism.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/Parallelism.java
@@ -1,0 +1,8 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+public enum Parallelism {
+    LOW,
+    MEDIUM,
+    HIGH,
+    OVERSUBSCRIBE
+}

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -26,7 +26,8 @@ class BulkLoadHandlerTest {
         var responseString = createSuccessResponseString();
         var httpClient = setUpSuccessfulHttpResponse(responseString);
         var handler = new BulkLoadHandler(httpClient);
-        handler.handleRequest(new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream(),
+        handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
+                              new ByteArrayOutputStream(),
                               new FakeContext());
         assertTrue(logger.getMessages().contains(responseString));
     }
@@ -37,7 +38,8 @@ class BulkLoadHandlerTest {
         var responseString = createFailingResponseString();
         var httpClient = setUpFailingHttpResponse(responseString);
         var handler = new BulkLoadHandler(httpClient);
-        handler.handleRequest(new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream(),
+        handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
+                              new ByteArrayOutputStream(),
                               new FakeContext());
         assertTrue(logger.getMessages().contains(responseString));
     }

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -1,0 +1,75 @@
+package no.sikt.nva.data.report.api.etl.loader;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.Test;
+
+class BulkLoadHandlerTest {
+
+    @Test
+    void shouldLogSuccessfulLoadingEvent() throws IOException, InterruptedException {
+        final var logger = LogUtils.getTestingAppenderForRootLogger();
+        var responseString = createSuccessResponseString();
+        var httpClient = setUpSuccessfulHttpResponse(responseString);
+        var handler = new BulkLoadHandler(httpClient);
+        handler.handleRequest(null, new ByteArrayOutputStream(), new FakeContext());
+        assertTrue(logger.getMessages().contains(responseString));
+    }
+
+    @Test
+    void shouldLogFailingLoadingEvent() throws IOException, InterruptedException {
+        final var logger = LogUtils.getTestingAppenderForRootLogger();
+        var responseString = createFailingResponseString();
+        var httpClient = setUpFailingHttpResponse(responseString);
+        var handler = new BulkLoadHandler(httpClient);
+        handler.handleRequest(null, new ByteArrayOutputStream(), new FakeContext());
+        assertTrue(logger.getMessages().contains(responseString));
+    }
+
+    private String createFailingResponseString() {
+        return """
+            {
+                "status" : "403 Forbidden"
+            }
+            """;
+    }
+
+    private HttpClient setUpFailingHttpResponse(String responseString)
+        throws IOException, InterruptedException {
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(403);
+        when(httpResponse.body()).thenReturn(responseString);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private static HttpClient setUpSuccessfulHttpResponse(String responseString)
+        throws IOException, InterruptedException {
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(responseString);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private static String createSuccessResponseString() {
+        return """
+            {
+                "status" : "200 OK",
+                "payload" : {
+                    "loadId" : "someUUID"
+                }
+            }
+            """;
+    }
+}

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +26,8 @@ class BulkLoadHandlerTest {
         var responseString = createSuccessResponseString();
         var httpClient = setUpSuccessfulHttpResponse(responseString);
         var handler = new BulkLoadHandler(httpClient);
-        handler.handleRequest(null, new ByteArrayOutputStream(), new FakeContext());
+        handler.handleRequest(new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream(),
+                              new FakeContext());
         assertTrue(logger.getMessages().contains(responseString));
     }
 
@@ -35,7 +37,8 @@ class BulkLoadHandlerTest {
         var responseString = createFailingResponseString();
         var httpClient = setUpFailingHttpResponse(responseString);
         var handler = new BulkLoadHandler(httpClient);
-        handler.handleRequest(null, new ByteArrayOutputStream(), new FakeContext());
+        handler.handleRequest(new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream(),
+                              new FakeContext());
         assertTrue(logger.getMessages().contains(responseString));
     }
 

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -53,7 +53,7 @@ class BulkLoadHandlerTest {
         var handler = new BulkLoadHandler(httpClient);
         var request = createErrorLogRequest(uuid);
         handler.handleRequest(request, new ByteArrayOutputStream(), new FakeContext());
-        assertTrue(logger.getMessages().contains("200 OK"));
+        assertTrue(logger.getMessages().contains(responseString));
     }
 
     private InputStream createErrorLogRequest(UUID uuid) {

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -53,7 +53,7 @@ class BulkLoadHandlerTest {
         var handler = new BulkLoadHandler(httpClient);
         var request = createErrorLogRequest(uuid);
         handler.handleRequest(request, new ByteArrayOutputStream(), new FakeContext());
-        assertTrue(logger.getMessages().contains(responseString));
+        assertTrue(logger.getMessages().contains("200 OK"));
     }
 
     private InputStream createErrorLogRequest(UUID uuid) {

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -1,14 +1,19 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
+import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
+import java.util.UUID;
+import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.ioutils.IoUtils;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +39,50 @@ class BulkLoadHandlerTest {
         assertTrue(logger.getMessages().contains(responseString));
     }
 
+    @Test
+    void shouldLogErrorLog() throws IOException, InterruptedException {
+        final var logger = LogUtils.getTestingAppenderForRootLogger();
+        var uuid = UUID.randomUUID();
+        var responseString = createErrorResponseLogString(uuid);
+        var httpClient = setUpErrorLogHttpResponse(responseString);
+        var handler = new BulkLoadHandler(httpClient);
+        var request = createErrorLogRequest(uuid);
+        handler.handleRequest(request, new ByteArrayOutputStream(), new FakeContext());
+        assertTrue(logger.getMessages().contains(responseString));
+    }
+
+    private InputStream createErrorLogRequest(UUID uuid) {
+        return IoUtils.stringToStream(asJson(new ErrorLogRequest(uuid, null, null)));
+    }
+
+    private String asJson(ErrorLogRequest errorLogRequest) {
+        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(errorLogRequest))
+                   .orElseThrow();
+    }
+
+    private String createErrorResponseLogString(UUID uuid) {
+        return """
+            {
+                "status" : "200 OK",
+                "payload" : {
+                    "failedFeeds" : [ ],
+                    "feedCount" : [
+                        {
+                            "LOAD_FAILED" : 1
+                        }
+                    ],
+                    "overallStatus" : { },
+                    "errors" : {
+                        "endIndex" : 3,
+                        "errorLogs" : [ ],
+                        "loadId" : "__UUID__",
+                        "startIndex" : 1
+                    }
+                }
+            }
+            """.replace("__UUID__", uuid.toString());
+    }
+
     private String createFailingResponseString() {
         return """
             {
@@ -53,6 +102,16 @@ class BulkLoadHandlerTest {
     }
 
     private static HttpClient setUpSuccessfulHttpResponse(String responseString)
+        throws IOException, InterruptedException {
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(responseString);
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private HttpClient setUpErrorLogHttpResponse(String responseString)
         throws IOException, InterruptedException {
         var httpClient = mock(HttpClient.class);
         var httpResponse = mock(HttpResponse.class);

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
 import static nva.commons.core.attempt.Try.attempt;
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
@@ -10,38 +12,45 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.UUID;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 class BulkLoadHandlerTest {
 
+    private static final String NEPTUNE_ENDPOINT = "NEPTUNE_ENDPOINT";
+    private static final String NEPTUNE_PORT = "NEPTUNE_PORT";
+
     @Test
     void shouldLogSuccessfulLoadingEvent() throws IOException, InterruptedException {
         final var logger = LogUtils.getTestingAppenderForRootLogger();
-        var responseString = createSuccessResponseString();
-        var httpClient = setUpSuccessfulHttpResponse(responseString);
+        var response = new Response(SC_OK, new SuccessPayload(UUID.randomUUID()));
+        var httpClient = setUpSuccessfulHttpResponse(response);
         var handler = new BulkLoadHandler(httpClient);
         handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
                               new ByteArrayOutputStream(),
                               new FakeContext());
-        assertTrue(logger.getMessages().contains(responseString));
+        assertTrue(logger.getMessages().contains(response.toString()));
     }
 
     @Test
     void shouldLogFailingLoadingEvent() throws IOException, InterruptedException {
         final var logger = LogUtils.getTestingAppenderForRootLogger();
-        var responseString = createFailingResponseString();
-        var httpClient = setUpFailingHttpResponse(responseString);
+        var response = new Response(HttpStatus.SC_FORBIDDEN, new SuccessPayload(UUID.randomUUID()));
+        var httpClient = setUpFailingHttpResponse(response);
         var handler = new BulkLoadHandler(httpClient);
         handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
                               new ByteArrayOutputStream(),
                               new FakeContext());
-        assertTrue(logger.getMessages().contains(responseString));
+        assertTrue(logger.getMessages().contains(response.toString()));
     }
 
     @Test
@@ -53,7 +62,7 @@ class BulkLoadHandlerTest {
         var handler = new BulkLoadHandler(httpClient);
         var request = createErrorLogRequest(uuid);
         handler.handleRequest(request, new ByteArrayOutputStream(), new FakeContext());
-        assertTrue(logger.getMessages().contains(responseString));
+        assertTrue(logger.getMessages().contains(responseString.toString()));
     }
 
     private InputStream createErrorLogRequest(UUID uuid) {
@@ -65,8 +74,89 @@ class BulkLoadHandlerTest {
                    .orElseThrow();
     }
 
-    private String createErrorResponseLogString(UUID uuid) {
-        return """
+    private Response createErrorResponseLogString(UUID uuid) {
+        return new Response(SC_OK, new ErrorPayload(uuid));
+    }
+
+    private HttpClient setUpFailingHttpResponse(Response response)
+        throws IOException, InterruptedException {
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(response.status());
+        when(httpResponse.body()).thenReturn(response.toString());
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private static HttpClient setUpSuccessfulHttpResponse(Response response)
+        throws IOException, InterruptedException {
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(response.status);
+        when(httpResponse.body()).thenReturn(response.toString());
+        when(httpClient.send(any(), any())).thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private HttpClient setUpErrorLogHttpResponse(Response response)
+        throws IOException, InterruptedException {
+        var environment = new Environment();
+        var host = environment.readEnv(NEPTUNE_ENDPOINT);
+        var port = Integer.parseInt(environment.readEnv(NEPTUNE_PORT));
+        var httpClient = mock(HttpClient.class);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(response.status());
+        when(httpResponse.body()).thenReturn(response.toString());
+        when(httpClient.send(matchErrorLogRequest(response, host, port), any()))
+            .thenReturn(httpResponse);
+        return httpClient;
+    }
+
+    private static HttpRequest matchErrorLogRequest(Response response, String host, int port) {
+        var uri = UriWrapper.fromHost(host, port)
+                      .addChild("loader")
+                      .addChild(response.payload().loadId().toString())
+                      .addQueryParameter("details", "true")
+                      .addQueryParameter("errors", "true")
+                      .addQueryParameter("page", String.valueOf(1))
+                      .addQueryParameter("errorsPerPage", String.valueOf(3))
+                      .getUri();
+
+        var request = HttpRequest.newBuilder()
+                          .GET()
+                          .header("Content-Type", "application/json")
+                          .uri(uri)
+                          .build();
+        return eq(request);
+    }
+
+    private record Response(int status, Payload payload) {
+
+        @Override
+        public String toString() {
+            return String.format("""
+                                     {
+                                         "status" : "%d",
+                                         "payload" : {
+                                             "loadId" : "%s"
+                                         }
+                                     }
+                                     """, status, payload.loadId());
+        }
+    }
+
+    private interface Payload {
+        UUID loadId();
+    }
+
+    private record SuccessPayload(UUID loadId) implements Payload {
+
+    }
+
+    private record ErrorPayload(UUID loadId) implements Payload {
+        @Override
+        public String toString() {
+            return """
             {
                 "status" : "200 OK",
                 "payload" : {
@@ -85,55 +175,7 @@ class BulkLoadHandlerTest {
                     }
                 }
             }
-            """.replace("__UUID__", uuid.toString());
-    }
-
-    private String createFailingResponseString() {
-        return """
-            {
-                "status" : "403 Forbidden"
-            }
-            """;
-    }
-
-    private HttpClient setUpFailingHttpResponse(String responseString)
-        throws IOException, InterruptedException {
-        var httpClient = mock(HttpClient.class);
-        var httpResponse = mock(HttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(403);
-        when(httpResponse.body()).thenReturn(responseString);
-        when(httpClient.send(any(), any())).thenReturn(httpResponse);
-        return httpClient;
-    }
-
-    private static HttpClient setUpSuccessfulHttpResponse(String responseString)
-        throws IOException, InterruptedException {
-        var httpClient = mock(HttpClient.class);
-        var httpResponse = mock(HttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(httpResponse.body()).thenReturn(responseString);
-        when(httpClient.send(any(), any())).thenReturn(httpResponse);
-        return httpClient;
-    }
-
-    private HttpClient setUpErrorLogHttpResponse(String responseString)
-        throws IOException, InterruptedException {
-        var httpClient = mock(HttpClient.class);
-        var httpResponse = mock(HttpResponse.class);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(httpResponse.body()).thenReturn(responseString);
-        when(httpClient.send(any(), any())).thenReturn(httpResponse);
-        return httpClient;
-    }
-
-    private static String createSuccessResponseString() {
-        return """
-            {
-                "status" : "200 OK",
-                "payload" : {
-                    "loadId" : "someUUID"
-                }
-            }
-            """;
+            """.replace("__UUID__", loadId.toString());
+        }
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -380,8 +380,6 @@ Resources:
       ServerlessScalingConfiguration:
         MaxCapacity: 128
         MinCapacity: 2.5
-      EnableCloudwatchLogsExports:
-        - audit
 
   NeptuneInstance1:
     Type: AWS::Neptune::DBInstance

--- a/template.yaml
+++ b/template.yaml
@@ -344,7 +344,7 @@ Resources:
           LOADER_BUCKET: !Ref LoaderBucketName
           NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
           NEPTUNE_PORT: 8182
-          LOADER_IAM_ROLE: !Get ReadAndListBucketPolicy.Arn
+          LOADER_IAM_ROLE: !GetAtt ReadAndListBucketPolicy.Arn
           AWS_REGION: !Ref AWS::Region
 
 
@@ -593,7 +593,7 @@ Resources:
                 Action:
                   - s3:Get*
                   - s3:List*
-                Resource: !Get LoaderBucket.Arn
+                Resource: !GetAtt LoaderBucket.Arn
 
 
 #### OUTPUTS ####

--- a/template.yaml
+++ b/template.yaml
@@ -380,6 +380,8 @@ Resources:
       ServerlessScalingConfiguration:
         MaxCapacity: 128
         MinCapacity: 2.5
+      EnableCloudwatchLogsExports:
+        - audit
 
   NeptuneInstance1:
     Type: AWS::Neptune::DBInstance

--- a/template.yaml
+++ b/template.yaml
@@ -381,7 +381,7 @@ Resources:
         MaxCapacity: 128
         MinCapacity: 2.5
       EnableCloudwatchLogsExports:
-        - error
+        - audit
 
   NeptuneInstance1:
     Type: AWS::Neptune::DBInstance

--- a/template.yaml
+++ b/template.yaml
@@ -604,7 +604,9 @@ Resources:
                 Action:
                   - s3:Get*
                   - s3:List*
-                Resource: !Sub '${LoaderBucket.Arn}/*'
+                Resource:
+                  - !GetAtt LoaderBucket.Arn
+                  - !Sub '${LoaderBucket.Arn}/*'
 
 
 #### OUTPUTS ####

--- a/template.yaml
+++ b/template.yaml
@@ -366,6 +366,8 @@ Resources:
   NeptuneCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
+      AssociatedRoles:
+        - RoleArn: !GetAtt ReadAndListBucketPolicy.Arn
       DBClusterIdentifier: !Ref ProjectName
       DBSubnetGroupName: !Ref NeptuneSubnets
       VpcSecurityGroupIds:

--- a/template.yaml
+++ b/template.yaml
@@ -341,7 +341,7 @@ Resources:
       AutoPublishAlias: live
       Environment:
         Variables:
-          LOADER_BUCKET: !Ref LoaderBucketName
+          LOADER_BUCKET: !Sub s3://${LoaderBucket}
           NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
           NEPTUNE_PORT: 8182
           LOADER_IAM_ROLE: !GetAtt ReadAndListBucketPolicy.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -328,6 +328,7 @@ Resources:
             Type: SQS
             Destination: !GetAtt DataLoadingDLQ.Arn
 
+
   BulkDataLoader:
     Type: AWS::Serverless::Function
     Properties:
@@ -344,6 +345,7 @@ Resources:
           NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
           NEPTUNE_PORT: 8182
           LOADER_IAM_ROLE: !Get ReadAndListBucketPolicy.Arn
+          AWS_REGION: !Ref AWS::Region
 
 
   ResetDatabaseButton:

--- a/template.yaml
+++ b/template.yaml
@@ -592,8 +592,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ rds.amazonaws.com ]
-            Action: [ 'sts:AssumeRole' ]
+              Service:
+                - rds.amazonaws.com
+            Action: sts:AssumeRole
       Policies:
         - PolicyName: listGetS3
           PolicyDocument:
@@ -603,7 +604,7 @@ Resources:
                 Action:
                   - s3:Get*
                   - s3:List*
-                Resource: !GetAtt LoaderBucket.Arn
+                Resource: !Sub '${LoaderBucket.Arn}/*'
 
 
 #### OUTPUTS ####

--- a/template.yaml
+++ b/template.yaml
@@ -544,6 +544,12 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
       SubnetId: !Ref LambdaSubnet1
 
+  PrivateRouteTableNeptuneAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet1
+
   S3GatewayEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -538,6 +538,12 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
       SubnetId: !Ref PrivateSubnet1
 
+  PrivateRouteTable2Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet2
+
   PrivateRouteTableLambdaAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -45,6 +45,10 @@ Parameters:
     Type: String
     Description: Prefix for nvi-candidate files in persisted-resources bucket
     Default: nvi-candidates/
+  LoaderBucketName:
+    Type: 'String'
+    Default: "loader-input-files"
+    Description: Name of bucket for input NQuads files
 
 Mappings:
   SubnetConfig:
@@ -324,6 +328,24 @@ Resources:
             Type: SQS
             Destination: !GetAtt DataLoadingDLQ.Arn
 
+  BulkDataLoader:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: bulk-load
+      Policies:
+        - VPCAccessPolicy: { }
+      Handler: no.sikt.nva.data.report.api.etl.loader.BulkLoadHandler::handleRequest
+      Timeout: 600
+      MemorySize: 1536
+      AutoPublishAlias: live
+      Environment:
+        Variables:
+          LOADER_BUCKET: !Ref LoaderBucketName
+          NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
+          NEPTUNE_PORT: 8182
+          LOADER_IAM_ROLE: !Get ReadAndListBucketPolicy.Arn
+
+
   ResetDatabaseButton:
     Type: AWS::Serverless::Function
     Properties:
@@ -535,6 +557,42 @@ Resources:
               - 's3:Get*'
               - 's3:List*'
             Resource: '*'
+
+    #---- Buckets ----
+  LoaderBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      BucketName: !Sub "${LoaderBucketName}-${AWS::AccountId}"
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteContentAfter3Days
+            Status: Enabled
+            ExpirationInDays: 3
+
+    #---- Role for Neptune load ----
+
+  ReadAndListBucketPolicy:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ rds.amazonaws.com ]
+            Action: [ 'sts:AssumeRole' ]
+      Policies:
+        - PolicyName: listGetS3
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:Get*
+                  - s3:List*
+                Resource: !Get LoaderBucket.Arn
+
 
 #### OUTPUTS ####
 Outputs:

--- a/template.yaml
+++ b/template.yaml
@@ -595,7 +595,7 @@ Resources:
                 Action:
                   - s3:Get*
                   - s3:List*
-                Resource: !Sub '${LoaderBucket}/*'
+                Resource: !GetAtt LoaderBucket.Arn
 
 
 #### OUTPUTS ####

--- a/template.yaml
+++ b/template.yaml
@@ -345,7 +345,7 @@ Resources:
           NEPTUNE_ENDPOINT: !GetAtt NeptuneCluster.Endpoint
           NEPTUNE_PORT: 8182
           LOADER_IAM_ROLE: !GetAtt ReadAndListBucketPolicy.Arn
-          AWS_REGION: !Ref AWS::Region
+          AWS_REGION_NAME: !Ref AWS::Region
 
 
   ResetDatabaseButton:

--- a/template.yaml
+++ b/template.yaml
@@ -380,6 +380,8 @@ Resources:
       ServerlessScalingConfiguration:
         MaxCapacity: 128
         MinCapacity: 2.5
+      EnableCloudwatchLogsExports:
+        - error
 
   NeptuneInstance1:
     Type: AWS::Neptune::DBInstance

--- a/template.yaml
+++ b/template.yaml
@@ -544,12 +544,6 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
       SubnetId: !Ref LambdaSubnet1
 
-  PrivateRouteTableNeptuneAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref PrivateRouteTable
-      SubnetId: !Ref PrivateSubnet1
-
   S3GatewayEndpoint:
     Type: 'AWS::EC2::VPCEndpoint'
     Properties:
@@ -601,7 +595,7 @@ Resources:
                 Action:
                   - s3:Get*
                   - s3:List*
-                Resource: !GetAtt LoaderBucket.Arn
+                Resource: !Sub '${LoaderBucket}/*'
 
 
 #### OUTPUTS ####


### PR DESCRIPTION
- Speculative template as I'm not sure exactly how to do things (we'll need to deploy in Sandbox to test)
- Adds a lambda that can be initiated to send a request to Neptune's /loader endpoint to read all NQuads files from a bucket and load these in bulk
- Since Neptune doesn't produce logs in the traditional sense, you need to query the loader endpoint with the loadId of the load request. I have implemented this functionality in this lambda since it is something that you should only need to do based on the request emitted by initiating this lambda. It could have been another lambda, but I don't see a huge value in creating more code right now. We may choose to split this code out later.