### PR TITLE
Np 46085 nvi endpoint, remaining headers

### DIFF
--- a/data-loading/src/main/resources/nvi_context.jsonld
+++ b/data-loading/src/main/resources/nvi_context.jsonld
@@ -11,6 +11,9 @@
     "notes": {
       "@id": "note",
       "@container": "@set"
+    },
+    "institutionId" : {
+      "@type" : "@id"
     }
   }
 }

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -23,6 +23,14 @@ SELECT DISTINCT
       ?affiliationUri a ?NviOrganization .
       BIND(STR(?affiliationUri) AS ?affiliationId)
 
+      ?approval a :Approval ;
+        :approvalStatus ?institutionApprovalStatus ;
+        :points ?institutionPoints ;
+        :institutionId ?organizationUriString .
+      BIND(URI(?organizationUriString) AS ?organizationUri)
+      ?affiliationUri :partOf ?organizationUri .
+      BIND(STR(?organizationUri) AS ?institutionId)
+
       FILTER(?modifiedDate >= "__AFTER__"^^xsd:dateTime)
       FILTER(?modifiedDate < "__BEFORE__"^^xsd:dateTime)
   }

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -23,6 +23,7 @@ SELECT DISTINCT
       ?affiliationUri a ?NviOrganization .
       BIND(STR(?affiliationUri) AS ?affiliationId)
 
+      ?candidate :approval ?approval .
       ?approval a :Approval ;
         :approvalStatus ?institutionApprovalStatus ;
         :points ?institutionPoints ;
@@ -34,4 +35,4 @@ SELECT DISTINCT
       FILTER(?modifiedDate >= "__AFTER__"^^xsd:dateTime)
       FILTER(?modifiedDate < "__BEFORE__"^^xsd:dateTime)
   }
-} ORDER BY ?publicationId LIMIT __PAGE_SIZE__
+} ORDER BY ?publicationId ?contributorIdentifier LIMIT __PAGE_SIZE__

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -27,8 +27,7 @@ SELECT DISTINCT
       ?approval a :Approval ;
         :approvalStatus ?institutionApprovalStatus ;
         :points ?institutionPoints ;
-        :institutionId ?organizationUriString .
-      BIND(URI(?organizationUriString) AS ?organizationUri)
+        :institutionId ?organizationUri .
       ?affiliationUri :partOf ?organizationUri .
       BIND(STR(?organizationUri) AS ?institutionId)
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -58,7 +58,6 @@ public class TestData {
     private static final String INSTITUTION_POINTS = "institutionPoints";
     private static final String INSTITUTION_APPROVAL_STATUS = "institutionApprovalStatus";
     private static final String PUBLICATION_DATE = "publicationDate";
-
     private static final BigDecimal MIN_BIG_DECIMAL = BigDecimal.ZERO;
     private static final BigDecimal MAX_BIG_DECIMAL = BigDecimal.TEN;
     private static final List<String> AFFILIATION_HEADERS = List.of(PUBLICATION_ID, PUBLICATION_IDENTIFIER,
@@ -81,6 +80,7 @@ public class TestData {
                                                             CONTRIBUTOR_IDENTIFIER,
                                                             AFFILIATION_ID, INSTITUTION_ID, INSTITUTION_POINTS,
                                                             INSTITUTION_APPROVAL_STATUS);
+    private static final String SOME_SUB_UNIT_IDENTIFIER = "10.1.1.2";
     private final List<TestPublication> publicationTestData;
 
     private final List<TestNviCandidate> nviTestData;
@@ -201,7 +201,7 @@ public class TestData {
     }
 
     private static TestOrganization generateAffiliation() {
-        return new TestOrganization(organizationUri("10.1.1.2"), "My university");
+        return new TestOrganization(organizationUri(SOME_SUB_UNIT_IDENTIFIER), "My university");
     }
 
     private static List<TestApproval> generateApprovals(TestPublicationDetails publicationDetails) {
@@ -248,7 +248,7 @@ public class TestData {
 
     private TestNviOrganization generateNviAffiliation() {
         return TestNviOrganization.builder()
-                   .withId(organizationUri("10.1.1.2"))
+                   .withId(organizationUri(SOME_SUB_UNIT_IDENTIFIER))
                    .build();
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -5,6 +5,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +57,9 @@ public class TestData {
     private static final String INSTITUTION_POINTS = "institutionPoints";
     private static final String INSTITUTION_APPROVAL_STATUS = "institutionApprovalStatus";
     private static final String PUBLICATION_DATE = "publicationDate";
+
+    private static final BigDecimal MIN_BIG_DECIMAL = BigDecimal.ZERO;
+    private static final BigDecimal MAX_BIG_DECIMAL = BigDecimal.TEN;
     private static final List<String> AFFILIATION_HEADERS = List.of(PUBLICATION_ID, PUBLICATION_IDENTIFIER,
                                                                     CONTRIBUTOR_ID, CONTRIBUTOR_NAME, AFFILIATION_ID,
                                                                     AFFILIATION_NAME, INSTITUTION_ID, FACULTY_ID,
@@ -87,6 +91,12 @@ public class TestData {
         this.nviTestData = generateNviData(dates);
         addPublicationDataToModel(publicationTestData);
         addNviDataToModel(nviTestData);
+    }
+
+    public static BigDecimal randomBigDecimal() {
+        var randomBigDecimal = MIN_BIG_DECIMAL.add(
+            BigDecimal.valueOf(Math.random()).multiply(MAX_BIG_DECIMAL.subtract(MIN_BIG_DECIMAL)));
+        return randomBigDecimal.setScale(4, RoundingMode.HALF_UP);
     }
 
     public Model getModel() {
@@ -201,7 +211,7 @@ public class TestData {
                             .map(topLevelOrganization -> TestApproval.builder()
                                                              .withInstitutionId(topLevelOrganization)
                                                              .withApprovalStatus(randomElement(ApprovalStatus.values()))
-                                                             .withPoints(BigDecimal.ONE)
+                                                             .withPoints(randomBigDecimal())
                                                              .build())
                             .toList();
         return TestNviCandidate.builder()

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -204,18 +204,26 @@ public class TestData {
         return new TestOrganization(organizationUri("10.1.1.2"), "My university");
     }
 
+    private static List<TestApproval> generateApprovals(TestPublicationDetails publicationDetails) {
+        return publicationDetails.contributors().stream()
+                   .flatMap(contributor -> contributor.affiliations().stream())
+                   .map(TestNviOrganization::getTopLevelOrganization)
+                   .distinct()
+                   .map(TestData::generateApproval)
+                   .toList();
+    }
+
+    private static TestApproval generateApproval(String topLevelOrganization) {
+        return TestApproval.builder()
+                   .withInstitutionId(URI.create(topLevelOrganization))
+                   .withApprovalStatus(randomElement(ApprovalStatus.values()))
+                   .withPoints(randomBigDecimal())
+                   .build();
+    }
+
     private TestNviCandidate generateNviCandidate(Instant modifiedDate) {
         var publicationDetails = generatePublicationDetails();
-        var approvals = publicationDetails.contributors().stream()
-                            .flatMap(contributor -> contributor.affiliations().stream())
-                            .map(TestNviOrganization::getTopLevelOrganization)
-                            .distinct()
-                            .map(topLevelOrganization -> TestApproval.builder()
-                                                             .withInstitutionId(URI.create(topLevelOrganization))
-                                                             .withApprovalStatus(randomElement(ApprovalStatus.values()))
-                                                             .withPoints(randomBigDecimal())
-                                                             .build())
-                            .toList();
+        var approvals = generateApprovals(publicationDetails);
         return TestNviCandidate.builder()
                    .withIdentifier(UUID.randomUUID().toString())
                    .withModifiedDate(modifiedDate)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -151,6 +151,7 @@ public class TestData {
     public String getNviResponseData() {
         var headers = String.join(DELIMITER, NVI_HEADERS) + CRLF.getString();
         nviTestData.sort(this::sortByPublicationUri);
+        nviTestData.forEach(candidate -> candidate.publicationDetails().contributors().sort(this::sortByContributor));
         var values = nviTestData.stream()
                          .map(TestNviCandidate::getExpectedNviResponse)
                          .collect(Collectors.joining());
@@ -225,7 +226,7 @@ public class TestData {
     private TestPublicationDetails generatePublicationDetails() {
         return TestPublicationDetails.builder()
                    .withId(randomUri().toString())
-                   .withContributors(List.of(generateNviContributor()))
+                   .withContributors(new ArrayList<>(List.of(generateNviContributor(), generateNviContributor())))
                    .build();
     }
 
@@ -278,6 +279,10 @@ public class TestData {
 
     private int sortByPublicationUri(TestNviCandidate a, TestNviCandidate b) {
         return a.publicationDetails().id().compareTo(b.publicationDetails().id());
+    }
+
+    private int sortByContributor(TestNviContributor a, TestNviContributor b) {
+        return a.id().compareTo(b.id());
     }
 
     public record DatePair(PublicationDate publicationDate, Instant modifiedDate) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -6,6 +6,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -210,7 +211,7 @@ public class TestData {
                             .map(TestNviOrganization::getTopLevelOrganization)
                             .distinct()
                             .map(topLevelOrganization -> TestApproval.builder()
-                                                             .withInstitutionId(topLevelOrganization)
+                                                             .withInstitutionId(URI.create(topLevelOrganization))
                                                              .withApprovalStatus(randomElement(ApprovalStatus.values()))
                                                              .withPoints(randomBigDecimal())
                                                              .build())

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
+import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
 import org.apache.jena.rdf.model.Model;
@@ -16,7 +17,7 @@ public class ApprovalGenerator extends TripleBasedBuilder {
 
     public ApprovalGenerator() {
         this.model = ModelFactory.createDefaultModel();
-        this.subject = model.createResource("someBlankNode");
+        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
         model.add(subject, TYPE, APPROVAL);
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -1,0 +1,47 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
+
+import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+
+public class ApprovalGenerator extends TripleBasedBuilder {
+
+    private static final Property APPROVAL = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "Approval");
+    private final Model model;
+    private final Resource subject;
+
+    public ApprovalGenerator() {
+        this.model = ModelFactory.createDefaultModel();
+        this.subject = model.createResource("someBlankNode");
+        model.add(subject, TYPE, APPROVAL);
+    }
+
+    public ApprovalGenerator withInstitutionId(String institutionId) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId"), institutionId);
+        return this;
+    }
+
+    public ApprovalGenerator withApprovalStatus(String approvalStatus) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "approvalStatus"), approvalStatus);
+        return this;
+    }
+
+    public ApprovalGenerator withPoints(String points) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points"), points);
+        return this;
+    }
+
+    @Override
+    public Model build() {
+        return model;
+    }
+
+    @Override
+    public Resource getSubject() {
+        return subject;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -13,6 +13,9 @@ import org.apache.jena.rdf.model.impl.PropertyImpl;
 public class ApprovalGenerator extends TripleBasedBuilder {
 
     private static final Property APPROVAL = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "Approval");
+    private static final String INSTITUTION_ID = "institutionId";
+    private static final String APPROVAL_STATUS = "approvalStatus";
+    private static final String POINTS = "points";
     private final Model model;
     private final Resource subject;
 
@@ -23,18 +26,18 @@ public class ApprovalGenerator extends TripleBasedBuilder {
     }
 
     public ApprovalGenerator withInstitutionId(OrganizationGenerator organizationGenerator) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId"),
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, INSTITUTION_ID),
                   organizationGenerator.subject);
         return this;
     }
 
     public ApprovalGenerator withApprovalStatus(String approvalStatus) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "approvalStatus"), approvalStatus);
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, APPROVAL_STATUS), approvalStatus);
         return this;
     }
 
     public ApprovalGenerator withPoints(String points) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points"), points);
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, POINTS), points);
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -3,6 +3,7 @@ package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -21,8 +22,9 @@ public class ApprovalGenerator extends TripleBasedBuilder {
         model.add(subject, TYPE, APPROVAL);
     }
 
-    public ApprovalGenerator withInstitutionId(String institutionId) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId"), institutionId);
+    public ApprovalGenerator withInstitutionId(OrganizationGenerator organizationGenerator) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId"),
+                  organizationGenerator.subject);
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -17,6 +17,7 @@ public class CandidateGenerator extends TripleBasedBuilder {
     private static final Property PUBLICATION_DETAILS = new PropertyImpl(ONTOLOGY_BASE_URI + "publicationDetails");
     private static final Property MODIFIED_DATE = new PropertyImpl(ONTOLOGY_BASE_URI + "modifiedDate");
     private static final Property IDENTIFIER = new PropertyImpl(ONTOLOGY_BASE_URI + "identifier");
+    private static final Property APPROVAL = new PropertyImpl(ONTOLOGY_BASE_URI + "Approval");
     private final Model model;
     private final Resource subject;
 
@@ -31,6 +32,12 @@ public class CandidateGenerator extends TripleBasedBuilder {
     public CandidateGenerator withPublicationDetails(PublicationDetailsGenerator publicationDetails) {
         model.add(subject, PUBLICATION_DETAILS, publicationDetails.getSubject());
         model.add(publicationDetails.build());
+        return this;
+    }
+
+    public CandidateGenerator withApproval(ApprovalGenerator approval) {
+        model.add(subject, APPROVAL, approval.getSubject());
+        model.add(approval.build());
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -17,7 +17,7 @@ public class CandidateGenerator extends TripleBasedBuilder {
     private static final Property PUBLICATION_DETAILS = new PropertyImpl(ONTOLOGY_BASE_URI + "publicationDetails");
     private static final Property MODIFIED_DATE = new PropertyImpl(ONTOLOGY_BASE_URI + "modifiedDate");
     private static final Property IDENTIFIER = new PropertyImpl(ONTOLOGY_BASE_URI + "identifier");
-    private static final Property APPROVAL = new PropertyImpl(ONTOLOGY_BASE_URI + "Approval");
+    private static final Property APPROVAL = new PropertyImpl(ONTOLOGY_BASE_URI + "approval");
     private final Model model;
     private final Resource subject;
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
@@ -12,6 +12,7 @@ import org.apache.jena.rdf.model.impl.PropertyImpl;
 public class NviOrganizationGenerator extends TripleBasedBuilder {
 
     private static final Property PART_OF = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "partOf");
+    private static final String NVI_ORGANIZATION = "NviOrganization";
 
     private final Model model;
     private final Resource subject;
@@ -19,7 +20,7 @@ public class NviOrganizationGenerator extends TripleBasedBuilder {
     public NviOrganizationGenerator(String id) {
         this.model = ModelFactory.createDefaultModel();
         this.subject = model.createResource(id);
-        model.add(subject, TYPE, model.createResource(Constants.ONTOLOGY_BASE_URI + "NviOrganization"));
+        model.add(subject, TYPE, model.createResource(Constants.ONTOLOGY_BASE_URI + NVI_ORGANIZATION));
     }
 
     public NviOrganizationGenerator withPartOf(List<String> partOfList) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
@@ -1,13 +1,18 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
+import static java.util.Objects.nonNull;
+import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
 
 public class NviOrganizationGenerator extends TripleBasedBuilder {
-
+    private static final Property PART_OF = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "partOf");
 
     private final Model model;
     private final Resource subject;
@@ -16,6 +21,11 @@ public class NviOrganizationGenerator extends TripleBasedBuilder {
         this.model = ModelFactory.createDefaultModel();
         this.subject = model.createResource(id);
         model.add(subject, TYPE, model.createResource(Constants.ONTOLOGY_BASE_URI + "NviOrganization"));
+    }
+
+    public NviOrganizationGenerator withPartOf(List<String> partOfList) {
+        partOfList.forEach(partOf -> model.add(subject, PART_OF, model.createResource(partOf)));
+        return this;
     }
 
     @Override

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/NviOrganizationGenerator.java
@@ -1,10 +1,8 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
-import static java.util.Objects.nonNull;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
-import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -12,6 +10,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.impl.PropertyImpl;
 
 public class NviOrganizationGenerator extends TripleBasedBuilder {
+
     private static final Property PART_OF = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "partOf");
 
     private final Model model;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/publication/OrganizationGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/publication/OrganizationGenerator.java
@@ -32,11 +32,11 @@ public class OrganizationGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public OrganizationGenerator withPartOf(OrganizationGenerator orgaanization) {
-        if (nonNull(orgaanization)) {
-            model.add(subject, PART_OF, orgaanization.getSubject());
-            model.add(orgaanization.getSubject(), HAS_PART, subject);
-            model.add(orgaanization.model);
+    public OrganizationGenerator withPartOf(OrganizationGenerator organization) {
+        if (nonNull(organization)) {
+            model.add(subject, PART_OF, organization.getSubject());
+            model.add(organization.getSubject(), HAS_PART, subject);
+            model.add(organization.model);
         }
         return this;
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
@@ -1,9 +1,10 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 
-public record TestApproval(String institutionId,
+public record TestApproval(URI institutionId,
                            ApprovalStatus approvalStatus,
                            BigDecimal points) {
 
@@ -34,14 +35,14 @@ public record TestApproval(String institutionId,
 
     public static final class Builder {
 
-        private String institutionId;
+        private URI institutionId;
         private ApprovalStatus approvalStatus;
         private BigDecimal points;
 
         private Builder() {
         }
 
-        public Builder withInstitutionId(String institutionId) {
+        public Builder withInstitutionId(URI institutionId) {
             this.institutionId = institutionId;
             return this;
         }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
 import java.math.BigDecimal;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 
 public record TestApproval(String institutionId,
                            ApprovalStatus approvalStatus,
@@ -10,13 +11,24 @@ public record TestApproval(String institutionId,
         return new Builder();
     }
 
+    public ApprovalGenerator toModel() {
+        return new ApprovalGenerator();
+    }
+
     public enum ApprovalStatus {
 
         PENDING("Pending"),
         APPROVED("Approved"),
         REJECTED("Rejected");
 
+        private final String value;
+
         ApprovalStatus(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
         }
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -14,7 +14,6 @@ public record TestNviCandidate(String identifier,
                                List<TestApproval> approvals) {
 
     public static final String DELIMITER = ",";
-    public static final String EMPTY_STRING = "";
 
     public static Builder builder() {
         return new Builder();

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -50,12 +50,17 @@ public record TestNviCandidate(String identifier,
 
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor,
                                              TestNviOrganization affiliation) {
+        var approval = approvals().stream()
+                           .filter(testApproval -> testApproval.institutionId()
+                                                       .equals(affiliation.getTopLevelOrganization()))
+                           .findFirst()
+                           .orElseThrow();
         stringBuilder.append(publicationDetails().id()).append(DELIMITER)
             .append(extractLastPathElement(contributor.id())).append(DELIMITER)
             .append(affiliation.id()).append(DELIMITER)
-            .append(affiliation.getTopLevelOrganization()).append(DELIMITER)
-            .append(EMPTY_STRING).append(DELIMITER)//TODO: InstitutionPoints
-            .append(EMPTY_STRING)//TODO: InstitutionApprovalStatus
+            .append(approval.institutionId()).append(DELIMITER)
+            .append(approval.points()).append(DELIMITER)
+            .append(approval.approvalStatus().getValue())
             .append(CRLF.getString());
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -51,11 +51,7 @@ public record TestNviCandidate(String identifier,
 
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor,
                                              TestNviOrganization affiliation) {
-        var approval = approvals().stream()
-                           .filter(testApproval -> testApproval.institutionId().toString()
-                                                       .equals(affiliation.getTopLevelOrganization()))
-                           .findFirst()
-                           .orElseThrow();
+        var approval = generateExpectedApprovals(affiliation);
         stringBuilder.append(publicationDetails().id()).append(DELIMITER)
             .append(extractLastPathElement(contributor.id())).append(DELIMITER)
             .append(affiliation.id()).append(DELIMITER)
@@ -63,6 +59,15 @@ public record TestNviCandidate(String identifier,
             .append(approval.points()).append(DELIMITER)
             .append(approval.approvalStatus().getValue())
             .append(CRLF.getString());
+    }
+
+    private TestApproval generateExpectedApprovals(TestNviOrganization affiliation) {
+        return approvals().stream()
+                   .filter(testApproval -> testApproval.institutionId()
+                                               .toString()
+                                               .equals(affiliation.getTopLevelOrganization()))
+                   .findFirst()
+                   .orElseThrow();
     }
 
     private String extractLastPathElement(String uri) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.CandidateGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.PublicationDetailsGenerator;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
 import nva.commons.core.paths.UriWrapper;
 import org.apache.jena.rdf.model.Model;
 
@@ -36,7 +37,8 @@ public record TestNviCandidate(String identifier,
         approvals().stream()
             .map(testApproval -> testApproval.toModel()
                                      .withApprovalStatus(testApproval.approvalStatus().getValue())
-                                     .withInstitutionId(testApproval.institutionId())
+                                     .withInstitutionId(
+                                         new OrganizationGenerator(testApproval.institutionId().toString()))
                                      .withPoints(testApproval.points().toString()))
             .forEach(nviCandidate::withApproval);
         return nviCandidate.build();
@@ -50,7 +52,7 @@ public record TestNviCandidate(String identifier,
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor,
                                              TestNviOrganization affiliation) {
         var approval = approvals().stream()
-                           .filter(testApproval -> testApproval.institutionId()
+                           .filter(testApproval -> testApproval.institutionId().toString()
                                                        .equals(affiliation.getTopLevelOrganization()))
                            .findFirst()
                            .orElseThrow();

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -34,6 +34,12 @@ public record TestNviCandidate(String identifier,
             .forEach(publicationDetails::withNviContributor);
         var nviCandidate = new CandidateGenerator(identifier, modifiedDate.toString())
                                .withPublicationDetails(publicationDetails);
+        approvals().stream()
+            .map(testApproval -> testApproval.toModel()
+                                     .withApprovalStatus(testApproval.approvalStatus().getValue())
+                                     .withInstitutionId(testApproval.institutionId())
+                                     .withPoints(testApproval.points().toString()))
+            .forEach(nviCandidate::withApproval);
         return nviCandidate.build();
     }
 
@@ -47,7 +53,7 @@ public record TestNviCandidate(String identifier,
         stringBuilder.append(publicationDetails().id()).append(DELIMITER)
             .append(extractLastPathElement(contributor.id())).append(DELIMITER)
             .append(affiliation.id()).append(DELIMITER)
-            .append(EMPTY_STRING).append(DELIMITER)//TODO: InstitutionId
+            .append(affiliation.getTopLevelOrganization()).append(DELIMITER)
             .append(EMPTY_STRING).append(DELIMITER)//TODO: InstitutionPoints
             .append(EMPTY_STRING)//TODO: InstitutionApprovalStatus
             .append(CRLF.getString());

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviOrganization.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviOrganization.java
@@ -1,15 +1,23 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
+import static java.util.Objects.isNull;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.NviOrganizationGenerator;
 
-public record TestNviOrganization(String id) {
-
-    public NviOrganizationGenerator toModel() {
-        return new NviOrganizationGenerator(id);
-    }
+public record TestNviOrganization(String id, List<String> partOf) {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public NviOrganizationGenerator toModel() {
+        return new NviOrganizationGenerator(id).withPartOf(partOf);
+    }
+
+    public String getTopLevelOrganization() {
+        return partOf.isEmpty() ? id() : partOf.stream().min(Comparator.naturalOrder()).get();
     }
 
     public static final class Builder {
@@ -25,7 +33,37 @@ public record TestNviOrganization(String id) {
         }
 
         public TestNviOrganization build() {
-            return new TestNviOrganization(id);
+            return new TestNviOrganization(id, generatePartOfList(id));
+        }
+
+        private List<String> generatePartOfList(String id) {
+            var partOfList = new ArrayList<String>();
+
+            if (isNull(id) || id.endsWith(".0.0.0")) {
+                return null;
+            }
+
+            int lastIndexOfSlash = id.lastIndexOf('/') + 1;
+            var identifier = id.substring(lastIndexOfSlash);
+            var baseUri = id.substring(0, lastIndexOfSlash);
+            var parts = identifier.split("\\.");
+            if (parts.length != 4) {
+                throw new RuntimeException(
+                    "The last path element in the organization URI should be formatted as 10.0.0.0");
+            }
+            if (parts[1].equals("0")) {
+                return null;
+            } else if (parts[2].equals("0")) {
+                partOfList.add(baseUri + parts[0] + ".0.0.0");
+            } else if (parts[3].equals("0")) {
+                partOfList.add(baseUri + parts[0] + ".0.0.0");
+                partOfList.add(baseUri + parts[0] + "." + parts[1] + ".0.0");
+            } else {
+                partOfList.add(baseUri + parts[0] + ".0.0.0");
+                partOfList.add(baseUri + parts[0] + "." + parts[1] + ".0.0");
+                partOfList.add(baseUri + parts[0] + "." + parts[1] + "." + parts[2] + ".0");
+            }
+            return partOfList;
         }
     }
 }


### PR DESCRIPTION
- Modified nvi sparql to provide the remaining headers `institutionId`, `institutionPoints` and `institutionApprovalStatus` to the nvi endpoint based on nvi approval data