### PR TITLE
Perform database reset

### DIFF
--- a/database-tools/build.gradle
+++ b/database-tools/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     implementation libs.nva.commons.core
     implementation libs.bundles.logging
 
+    implementation libs.jackson.core
+    implementation libs.jackson.databind
+    implementation libs.nva.json
+
     testImplementation libs.nva.testutils
 }
 

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
@@ -48,19 +48,23 @@ public class DatabaseResetHandler implements RequestStreamHandler {
                               OutputStream outputStream,
                               Context context) throws IOException {
         try {
-            var response = httpClient.send(buildHttpRequest(ACTION_INITIATE_DATABASE_RESET), BodyHandlers.ofString());
-            if (response.statusCode() == HTTP_OK) {
-                logger.info("Successfully submitted initialize reset request");
-                var token = parseResponseBody(response);
-                sendPerformDatabaseResetRequest(token.token());
-            } else {
-                logger.error("Initialize database reset request failed, received status from upstream {}",
-                             response.statusCode());
-                throw new DatabaseResetRequestException();
-            }
+            sendDatabaseResetRequests();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        }
+    }
+
+    private void sendDatabaseResetRequests() throws IOException, InterruptedException {
+        var response = httpClient.send(buildHttpRequest(ACTION_INITIATE_DATABASE_RESET), BodyHandlers.ofString());
+        if (response.statusCode() == HTTP_OK) {
+            logger.info("Successfully submitted initialize reset request");
+            var token = parseResponseBody(response);
+            sendPerformDatabaseResetRequest(token.token());
+        } else {
+            logger.error("Initialize database reset request failed, received status from upstream {}",
+                         response.statusCode());
+            throw new DatabaseResetRequestException();
         }
     }
 

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
@@ -63,8 +63,8 @@ public class DatabaseResetHandler implements RequestStreamHandler {
         var response = httpClient.send(buildHttpRequest(ACTION_INITIATE_DATABASE_RESET), BodyHandlers.ofString());
         if (response.statusCode() == HTTP_OK) {
             logger.info("Successfully submitted initialize reset request");
-            var token = parseResponseBody(response);
-            sendPerformDatabaseResetRequest(token.token());
+            var tokenResponse = parseResponseBody(response);
+            sendPerformDatabaseResetRequest(tokenResponse.token());
         } else {
             logger.error("Initialize database reset request failed, received status from upstream {}",
                          response.statusCode());

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
@@ -1,6 +1,8 @@
 package no.sikt.nva.data.report.dbtools;
 
 import static no.sikt.nva.data.report.dbtools.ResetAction.ACTION_INITIATE_DATABASE_RESET;
+import static no.sikt.nva.data.report.dbtools.ResetAction.ACTION_PERFORM_DATABASE_RESET;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import java.io.IOException;
@@ -12,6 +14,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import no.sikt.nva.data.report.dbtools.exception.DatabaseResetRequestException;
+import no.sikt.nva.data.report.dbtools.model.TokenResponse;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
@@ -19,12 +22,12 @@ import org.slf4j.LoggerFactory;
 
 public class DatabaseResetHandler implements RequestStreamHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(DatabaseResetHandler.class);
-    private static final String CONTENT_TYPE = "Content-Type";
     public static final String NEPTUNE_SYSTEM_TEMPLATE = "https://%s:%s/system";
     public static final String NEPTUNE_ENDPOINT = "NEPTUNE_ENDPOINT";
     public static final String NEPTUNE_PORT = "NEPTUNE_PORT";
     public static final int HTTP_OK = 200;
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseResetHandler.class);
+    private static final String CONTENT_TYPE = "Content-Type";
     private final HttpClient httpClient;
     private final Environment environment;
 
@@ -43,11 +46,13 @@ public class DatabaseResetHandler implements RequestStreamHandler {
                               OutputStream outputStream,
                               Context context) throws IOException {
         try {
-            var response = httpClient.send(buildHttpRequest(), BodyHandlers.ofString());
-            if (response.statusCode() == HTTP_OK) {
+            var tokenResponse = httpClient.send(buildHttpRequest(ACTION_INITIATE_DATABASE_RESET), BodyHandlers.ofString());
+            if (tokenResponse.statusCode() == HTTP_OK) {
                 logger.info("Successfully submitted reset request");
+                var token = dtoObjectMapper.readValue(tokenResponse.body(), TokenResponse.class).token();
+                httpClient.send(buildPerformResetRequest(token), BodyHandlers.ofString());
             } else {
-                logger.error("Request failed, received status from upstream {}", response.statusCode());
+                logger.error("Request failed, received status from upstream {}", tokenResponse.statusCode());
                 throw new DatabaseResetRequestException();
             }
         } catch (InterruptedException e) {
@@ -56,9 +61,13 @@ public class DatabaseResetHandler implements RequestStreamHandler {
         }
     }
 
-    private HttpRequest buildHttpRequest() {
+    private HttpRequest buildPerformResetRequest(String token) {
+        return buildHttpRequest(String.format(ACTION_PERFORM_DATABASE_RESET, token));
+    }
+
+    private HttpRequest buildHttpRequest(String requestBody) {
         return HttpRequest.newBuilder()
-                   .POST(BodyPublishers.ofString(ACTION_INITIATE_DATABASE_RESET))
+                   .POST(BodyPublishers.ofString(requestBody))
                    .header(CONTENT_TYPE, "application/json")
                    .uri(getUri())
                    .build();

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
@@ -55,6 +55,10 @@ public class DatabaseResetHandler implements RequestStreamHandler {
         }
     }
 
+    private static TokenResponse parseResponseBody(HttpResponse<String> response) throws JsonProcessingException {
+        return dtoObjectMapper.readValue(response.body(), TokenResponse.class);
+    }
+
     private void sendDatabaseResetRequests() throws IOException, InterruptedException {
         var response = httpClient.send(buildHttpRequest(ACTION_INITIATE_DATABASE_RESET), BodyHandlers.ofString());
         if (response.statusCode() == HTTP_OK) {
@@ -66,10 +70,6 @@ public class DatabaseResetHandler implements RequestStreamHandler {
                          response.statusCode());
             throw new DatabaseResetRequestException();
         }
-    }
-
-    private static TokenResponse parseResponseBody(HttpResponse<String> response) throws JsonProcessingException {
-        return dtoObjectMapper.readValue(response.body(), TokenResponse.class);
     }
 
     private void sendPerformDatabaseResetRequest(String token) throws IOException, InterruptedException {

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandler.java
@@ -24,11 +24,11 @@ import org.slf4j.LoggerFactory;
 
 public class DatabaseResetHandler implements RequestStreamHandler {
 
-    public static final String NEPTUNE_SYSTEM_TEMPLATE = "https://%s:%s/system";
-    public static final String NEPTUNE_ENDPOINT = "NEPTUNE_ENDPOINT";
-    public static final String NEPTUNE_PORT = "NEPTUNE_PORT";
-    public static final int HTTP_OK = 200;
     private static final Logger logger = LoggerFactory.getLogger(DatabaseResetHandler.class);
+    private static final String NEPTUNE_SYSTEM_TEMPLATE = "https://%s:%s/system";
+    private static final String NEPTUNE_ENDPOINT = "NEPTUNE_ENDPOINT";
+    private static final String NEPTUNE_PORT = "NEPTUNE_PORT";
+    private static final int HTTP_OK = 200;
     private static final String CONTENT_TYPE = "Content-Type";
     private final HttpClient httpClient;
     private final Environment environment;

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/ResetAction.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/ResetAction.java
@@ -6,6 +6,10 @@ public final class ResetAction {
         { "action" : "initiateDatabaseReset" }
         """;
 
+    public static final String ACTION_PERFORM_DATABASE_RESET = """
+        { "action" : "performDatabaseReset", "token": "%s"}
+        """;
+
     private ResetAction() {
         // NO-OP
     }

--- a/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/model/TokenResponse.java
+++ b/database-tools/src/main/java/no/sikt/nva/data/report/dbtools/model/TokenResponse.java
@@ -1,0 +1,8 @@
+package no.sikt.nva.data.report.dbtools.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+public record TokenResponse (String token){
+
+}

--- a/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
+++ b/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
@@ -20,7 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import no.sikt.nva.data.report.dbtools.exception.DatabaseResetRequestException;
 import no.unit.nva.stubs.FakeContext;
-import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.Test;
 

--- a/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
+++ b/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
@@ -11,31 +11,46 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import no.sikt.nva.data.report.dbtools.exception.DatabaseResetRequestException;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.Test;
 
 class DatabaseResetHandlerTest {
 
     private static final Context CONTEXT = new FakeContext();
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String NEPTUNE_SYSTEM_TEMPLATE = "https://%s:%s/system";
+    private static final Environment environment = new Environment();
+    private static final String NEPTUNE_PORT = environment.readEnv("NEPTUNE_PORT");
+    private static final String NEPTUNE_ENDPOINT = environment.readEnv("NEPTUNE_ENDPOINT");
+    private static final URI DATABASE_ENDPOINT = URI.create(String.format(NEPTUNE_SYSTEM_TEMPLATE,
+                                                                          NEPTUNE_ENDPOINT,
+                                                                          NEPTUNE_PORT));
+    private static final String TEST_TOKEN = UUID.randomUUID().toString();
 
     @Test
     void shouldSendResetRequestToNeptune() throws IOException, InterruptedException {
         final var logger = LogUtils.getTestingAppenderForRootLogger();
-        var httpClient = mockSuccessfulRequest();
+        var initializeRequest = buildInitializationRequest();
+        var performRequest = buildPerformRequest();
+        var httpClient = mockSuccessfulRequest(initializeRequest, performRequest);
         var handler = new DatabaseResetHandler(httpClient);
         var request = new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8));
         handler.handleRequest(request, null, CONTEXT);
-        verify(httpClient, times(1)).send(any(), any());
+        verify(httpClient, times(1)).send(eq(initializeRequest), any());
+        verify(httpClient, times(1)).send(eq(performRequest), any());
         assertTrue(logger.getMessages().contains("Successfully submitted reset request"));
     }
-
 
     @Test
     void shouldLogFailure() throws IOException, InterruptedException {
@@ -57,13 +72,18 @@ class DatabaseResetHandlerTest {
         assertTrue(exception.getMessage().contains("java.lang.InterruptedException"));
     }
 
-    private HttpClient mockSuccessfulRequest() throws IOException, InterruptedException {
+    private static HttpClient mockSuccessfulRequest(HttpRequest initializeRequest, HttpRequest performRequest)
+        throws IOException, InterruptedException {
         var httpClient = mock(HttpClient.class);
-        var httpResponse = (HttpResponse<String>) mock(HttpResponse.class);
-        when(httpClient.send(any(), eq(BodyHandlers.ofString()))).thenReturn(httpResponse);
-        when(httpResponse.statusCode()).thenReturn(200);
-        when(httpResponse.body()).thenReturn(neptuneResponse());
+        mockClient(initializeRequest, neptuneInitializationResponse(), httpClient);
+        mockClient(performRequest, neptunePerformResponse(), httpClient);
         return httpClient;
+    }
+
+    private static void mockClient(HttpRequest request, String responseBody, HttpClient httpClient)
+        throws IOException, InterruptedException {
+        var httpResponse = createResponse(responseBody);
+        when(httpClient.send(eq(request), eq(BodyHandlers.ofString()))).thenReturn(httpResponse);
     }
 
     private static HttpClient mockRequestFailure() throws IOException, InterruptedException {
@@ -75,14 +95,50 @@ class DatabaseResetHandlerTest {
         return httpClient;
     }
 
-    private String neptuneResponse() {
+    private static HttpRequest buildHttpRequest(String body) {
+        return HttpRequest.newBuilder()
+                   .POST(BodyPublishers.ofString(body))
+                   .header(CONTENT_TYPE, "application/json")
+                   .uri(DATABASE_ENDPOINT)
+                   .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<String> createResponse(String body) {
+        var response = (HttpResponse<String>) mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(body);
+        return response;
+    }
+
+    private static HttpRequest buildPerformRequest() {
+        return buildHttpRequest(String.format("""
+                                                  { "action" : "performDatabaseReset", "token" : "%s"}
+                                                  """, TEST_TOKEN));
+    }
+
+    private static HttpRequest buildInitializationRequest() {
+        return buildHttpRequest("""
+                                    { "action" : "initiateDatabaseReset" }
+                                    """);
+    }
+
+    private static String neptuneInitializationResponse() {
         return String.format("""
-            {
-              "status" : "200 OK",
-              "payload" : {
-                "token" : "%s"
-              }
-            }
-        """, UUID.randomUUID());
+                                     {
+                                       "status" : "200 OK",
+                                       "payload" : {
+                                         "token" : "%s"
+                                       }
+                                     }
+                                 """, DatabaseResetHandlerTest.TEST_TOKEN);
+    }
+
+    private static String neptunePerformResponse() {
+        return """
+                {
+                  "status" : "200 OK"
+                }
+            """;
     }
 }

--- a/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
+++ b/database-tools/src/test/java/no/sikt/nva/data/report/dbtools/DatabaseResetHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.dbtools;
 
+import static java.util.Objects.nonNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,16 +77,17 @@ class DatabaseResetHandlerTest {
         throws IOException, InterruptedException {
         var httpClient = mock(HttpClient.class);
         mockClient(initializeRequest, neptuneInitializationResponse(), httpClient);
-        mockClient(performRequest, neptunePerformResponse(), httpClient);
+        //mockClient(performRequest, null, httpClient);
         return httpClient;
     }
 
     private static void mockClient(HttpRequest request, String responseBody, HttpClient httpClient)
         throws IOException, InterruptedException {
-        var httpResponse = createResponse(responseBody);
+        var httpResponse = createSuccessfulResponse(responseBody);
         when(httpClient.send(eq(request), eq(BodyHandlers.ofString()))).thenReturn(httpResponse);
     }
 
+    @SuppressWarnings("unchecked")
     private static HttpClient mockRequestFailure() throws IOException, InterruptedException {
         var httpClient = mock(HttpClient.class);
         var httpResponse = (HttpResponse<String>) mock(HttpResponse.class);
@@ -104,10 +106,12 @@ class DatabaseResetHandlerTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static HttpResponse<String> createResponse(String body) {
+    private static HttpResponse<String> createSuccessfulResponse(String body) {
         var response = (HttpResponse<String>) mock(HttpResponse.class);
         when(response.statusCode()).thenReturn(200);
-        when(response.body()).thenReturn(body);
+        if (nonNull(body)){
+            when(response.body()).thenReturn(body);
+        }
         return response;
     }
 
@@ -125,20 +129,9 @@ class DatabaseResetHandlerTest {
 
     private static String neptuneInitializationResponse() {
         return String.format("""
-                                     {
-                                       "status" : "200 OK",
-                                       "payload" : {
-                                         "token" : "%s"
-                                       }
-                                     }
+                                 {
+                                    "token" : "%s"
+                                 }
                                  """, DatabaseResetHandlerTest.TEST_TOKEN);
-    }
-
-    private static String neptunePerformResponse() {
-        return """
-                {
-                  "status" : "200 OK"
-                }
-            """;
     }
 }


### PR DESCRIPTION
After successful `initializeDatabaseReset` action, use provided token to request `performDatabaseReset` action.
Docs: https://aws.amazon.com/blogs/database/resetting-your-graph-data-in-amazon-neptune-in-seconds/