### PR TITLE
Rename KeyBatchesBucketName to "data-report-key-batches"

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -51,7 +51,7 @@ Parameters:
     Description: Name of bucket for input NQuads files
   KeyBatchesBucketName:
     Type: 'String'
-    Default: "key-batches"
+    Default: "data-report-key-batches"
     Description: Name of bucket for key batch files
 
 Mappings:


### PR DESCRIPTION
Deployment failed due to `key-batches-{AccountId} already exists in stack`. Renamed to` data-report-key-batches`