### PR TITLE
Np 46247 Supply more nvi data, globalApprovalStatus and more

### DIFF
--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -8,6 +8,12 @@ SELECT DISTINCT
   ?institutionId
   ?institutionPoints
   ?institutionApprovalStatus
+  ?globalApprovalStatus
+  ?reportedPeriod
+  ?totalPoints
+  ?publicationTypeChannelLevelPoints
+  ?authorShareCount
+  ?internationalCollaborationFactor
   ?isApplicable
 WHERE {
   GRAPH ?g {
@@ -15,7 +21,16 @@ WHERE {
       ?candidate a :NviCandidate ;
         :modifiedDate ?modifiedDate ;
         :publicationDetails ?publicationUri ;
-        :isApplicable ?isApplicableBoolean .
+        :isApplicable ?isApplicableBoolean ;
+        :points ?totalPoints ;
+        :globalApprovalStatus ?globalApprovalStatus ;
+        :internationalCollaborationFactor ?internationalCollaborationFactor ;
+        :creatorShareCount ?authorShareCount ;
+        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
+
+      OPTIONAL {
+        ?candidate :reportedPeriod ?reportedPeriod .
+      }
 
       BIND(STR(?publicationUri) AS ?publicationId)
       BIND(STR(?isApplicableBoolean) AS ?isApplicable)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval.ApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate.Builder;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestPublicationDetails;
@@ -63,7 +64,7 @@ public class TestData {
     private static final String PUBLICATION_DATE = "publicationDate";
     private static final String TOTAL_POINTS = "totalPoints";
     private static final String PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS = "publicationTypeChannelLevelPoints";
-    private static final String CREATOR_SHARE_COUNT = "creatorShareCount";
+    private static final String AUTHOR_SHARE_COUNT = "authorShareCount";
     private static final String INTERNATIONAL_COLLABORATION_FACTOR = "internationalCollaborationFactor";
     private static final String REPORTED_PERIOD = "reportedPeriod";
     private static final String GLOBAL_APPROVAL_STATUS = "globalApprovalStatus";
@@ -111,7 +112,7 @@ public class TestData {
                                                             REPORTED_PERIOD,
                                                             TOTAL_POINTS,
                                                             PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS,
-                                                            CREATOR_SHARE_COUNT,
+                                                            AUTHOR_SHARE_COUNT,
                                                             INTERNATIONAL_COLLABORATION_FACTOR,
                                                             IS_APPLICABLE);
     private static final String SOME_SUB_UNIT_IDENTIFIER = "10.1.1.2";
@@ -258,9 +259,9 @@ public class TestData {
                    .build();
     }
 
-    private static TestNviCandidate buildCandidate(boolean isApplicable, Instant modifiedDate,
-                                                   TestPublicationDetails publicationDetails,
-                                                   List<TestApproval> approvals) {
+    private static Builder getCandidateBuilder(boolean isApplicable, Instant modifiedDate,
+                                               TestPublicationDetails publicationDetails,
+                                               List<TestApproval> approvals) {
         return TestNviCandidate.builder()
                    .withIsApplicable(isApplicable)
                    .withIdentifier(UUID.randomUUID().toString())
@@ -269,11 +270,9 @@ public class TestData {
                    .withApprovals(approvals)
                    .withCreatorShareCount(countCombinationsOfCreatorsAndAffiliations(publicationDetails))
                    .withInternationalCollaborationFactor(BigDecimal.ONE)
-                   .withReportedPeriod("2021")
                    .withGlobalApprovalStatus(ApprovalStatus.PENDING.getValue())
                    .withPublicationTypeChannelLevelPoints(randomBigDecimal())
-                   .withTotalPoints(randomBigDecimal())
-                   .build();
+                   .withTotalPoints(randomBigDecimal());
     }
 
     private static int countCombinationsOfCreatorsAndAffiliations(TestPublicationDetails publicationDetails) {
@@ -287,12 +286,20 @@ public class TestData {
     private TestNviCandidate generateNviCandidate(Instant modifiedDate) {
         var publicationDetails = generatePublicationDetails();
         var approvals = generateApprovals(publicationDetails);
-        return buildCandidate(true, modifiedDate, publicationDetails, approvals);
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals).build();
+    }
+
+    private TestNviCandidate generateReportedNviCandidate(Instant modifiedDate) {
+        var publicationDetails = generatePublicationDetails();
+        var approvals = generateApprovals(publicationDetails);
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals)
+                   .withReportedPeriod("2021")
+                   .build();
     }
 
     @SuppressWarnings("unchecked")
     private TestNviCandidate generateNonApplicableNviCandidate(Instant modifiedDate) {
-        return buildCandidate(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST);
+        return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST).build();
     }
 
     private TestPublicationDetails generatePublicationDetails() {
@@ -342,8 +349,10 @@ public class TestData {
         for (DatePair date : dates) {
             var nviCandidate = generateNviCandidate(date.modifiedDate);
             var nonApplicableNviCandidate = generateNonApplicableNviCandidate(date.modifiedDate);
+            var reportedCandidate = generateReportedNviCandidate(date.modifiedDate);
             dataSet.add(nviCandidate);
             dataSet.add(nonApplicableNviCandidate);
+            dataSet.add(reportedCandidate);
         }
         return dataSet;
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -19,6 +19,14 @@ public class CandidateGenerator extends TripleBasedBuilder {
     private static final Property IDENTIFIER = new PropertyImpl(ONTOLOGY_BASE_URI + "identifier");
     private static final Property APPROVAL = new PropertyImpl(ONTOLOGY_BASE_URI + "approval");
     private static final Property IS_APPLICABLE = new PropertyImpl(ONTOLOGY_BASE_URI + "isApplicable");
+    private static final Property POINTS = new PropertyImpl(ONTOLOGY_BASE_URI + "points");
+    private static final Property PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS = new PropertyImpl(
+        ONTOLOGY_BASE_URI + "publicationTypeChannelLevelPoints");
+    private static final Property CREATOR_SHARE_COUNT = new PropertyImpl(ONTOLOGY_BASE_URI + "creatorShareCount");
+    private static final Property INTERNATIONAL_COLLABORATION_FACTOR = new PropertyImpl(
+        ONTOLOGY_BASE_URI + "internationalCollaborationFactor");
+    private static final Property REPORTED_PERIOD = new PropertyImpl(ONTOLOGY_BASE_URI + "reportedPeriod");
+    private static final Property GLOBAL_APPROVAL_STATUS = new PropertyImpl(ONTOLOGY_BASE_URI + "globalApprovalStatus");
     private final Model model;
     private final Resource subject;
 
@@ -44,6 +52,38 @@ public class CandidateGenerator extends TripleBasedBuilder {
 
     public CandidateGenerator withIsApplicable(boolean isApplicable) {
         model.add(subject, IS_APPLICABLE, model.createTypedLiteral(isApplicable));
+        return this;
+    }
+
+    public CandidateGenerator withPoints(String points) {
+        model.add(subject, POINTS, model.createTypedLiteral(points));
+        return this;
+    }
+
+    public CandidateGenerator withPublicationTypeChannelLevelPoints(String publicationTypeChannelLevelPoints) {
+        model.add(subject, PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS,
+                  model.createTypedLiteral(publicationTypeChannelLevelPoints));
+        return this;
+    }
+
+    public CandidateGenerator withCreatorShareCount(String creatorShareCount) {
+        model.add(subject, CREATOR_SHARE_COUNT, model.createTypedLiteral(creatorShareCount));
+        return this;
+    }
+
+    public CandidateGenerator withInternationalCollaborationFactor(String internationalCollaborationFactor) {
+        model.add(subject, INTERNATIONAL_COLLABORATION_FACTOR,
+                  model.createTypedLiteral(internationalCollaborationFactor));
+        return this;
+    }
+
+    public CandidateGenerator withReportedPeriod(String reportedPeriod) {
+        model.add(subject, REPORTED_PERIOD, model.createTypedLiteral(reportedPeriod));
+        return this;
+    }
+
+    public CandidateGenerator withGlobalApprovalStatus(String globalApprovalStatus) {
+        model.add(subject, GLOBAL_APPROVAL_STATUS, model.createTypedLiteral(globalApprovalStatus));
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
+import static java.util.Objects.nonNull;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.Constants.ONTOLOGY_BASE_URI;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
@@ -78,7 +79,9 @@ public class CandidateGenerator extends TripleBasedBuilder {
     }
 
     public CandidateGenerator withReportedPeriod(String reportedPeriod) {
-        model.add(subject, REPORTED_PERIOD, model.createTypedLiteral(reportedPeriod));
+        if (nonNull(reportedPeriod)) {
+            model.add(subject, REPORTED_PERIOD, model.createTypedLiteral(reportedPeriod));
+        }
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -142,10 +142,6 @@ public record TestNviCandidate(String identifier,
         private Builder() {
         }
 
-        public static Builder aTestNviCandidate() {
-            return new Builder();
-        }
-
         public Builder withIdentifier(String identifier) {
             this.identifier = identifier;
             return this;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -4,6 +4,7 @@ import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.CandidateGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.PublicationDetailsGenerator;
@@ -103,7 +104,7 @@ public record TestNviCandidate(String identifier,
             .append(approval.points()).append(DELIMITER)
             .append(approval.approvalStatus().getValue()).append(DELIMITER)
             .append(globalApprovalStatus).append(DELIMITER)
-            .append(reportedPeriod).append(DELIMITER)
+            .append(Objects.nonNull(reportedPeriod) ? reportedPeriod : "").append(DELIMITER)
             .append(totalPoints).append(DELIMITER)
             .append(publicationTypeChannelLevelPoints).append(DELIMITER)
             .append(creatorShareCount).append(DELIMITER)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
@@ -14,7 +15,13 @@ public record TestNviCandidate(String identifier,
                                boolean isApplicable,
                                Instant modifiedDate,
                                TestPublicationDetails publicationDetails,
-                               List<TestApproval> approvals) {
+                               List<TestApproval> approvals,
+                               BigDecimal totalPoints,
+                               BigDecimal publicationTypeChannelLevelPoints,
+                               int creatorShareCount,
+                               BigDecimal internationalCollaborationFactor,
+                               String reportedPeriod,
+                               String globalApprovalStatus) {
 
     public static final String DELIMITER = ",";
 
@@ -51,12 +58,8 @@ public record TestNviCandidate(String identifier,
 
     private void generateExpectedLinesForNonApplicableCandidate(StringBuilder stringBuilder) {
         stringBuilder.append(publicationDetails().id())
-            .append(DELIMITER)
-            .append(DELIMITER)
-            .append(DELIMITER)
-            .append(DELIMITER)
-            .append(DELIMITER)
-            .append(DELIMITER)
+            .append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER)
+            .append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER).append(DELIMITER)
             .append(isApplicable())
             .append(CRLF.getString());
     }
@@ -76,7 +79,13 @@ public record TestNviCandidate(String identifier,
     private CandidateGenerator getCandidateGenerator(PublicationDetailsGenerator publicationDetails) {
         return new CandidateGenerator(identifier, modifiedDate.toString())
                    .withIsApplicable(isApplicable)
-                   .withPublicationDetails(publicationDetails);
+                   .withPublicationDetails(publicationDetails)
+                   .withPoints(totalPoints.toString())
+                   .withPublicationTypeChannelLevelPoints(publicationTypeChannelLevelPoints.toString())
+                   .withCreatorShareCount(String.valueOf(creatorShareCount))
+                   .withInternationalCollaborationFactor(internationalCollaborationFactor.toString())
+                   .withReportedPeriod(reportedPeriod)
+                   .withGlobalApprovalStatus(globalApprovalStatus);
     }
 
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor) {
@@ -93,6 +102,12 @@ public record TestNviCandidate(String identifier,
             .append(approval.institutionId()).append(DELIMITER)
             .append(approval.points()).append(DELIMITER)
             .append(approval.approvalStatus().getValue()).append(DELIMITER)
+            .append(globalApprovalStatus).append(DELIMITER)
+            .append(reportedPeriod).append(DELIMITER)
+            .append(totalPoints).append(DELIMITER)
+            .append(publicationTypeChannelLevelPoints).append(DELIMITER)
+            .append(creatorShareCount).append(DELIMITER)
+            .append(internationalCollaborationFactor).append(DELIMITER)
             .append(isApplicable())
             .append(CRLF.getString());
     }
@@ -117,8 +132,18 @@ public record TestNviCandidate(String identifier,
         private Instant modifiedDate;
         private TestPublicationDetails publicationDetails;
         private List<TestApproval> approvals;
+        private BigDecimal totalPoints;
+        private BigDecimal publicationTypeChannelLevelPoints;
+        private int creatorShareCount;
+        private BigDecimal internationalCollaborationFactor;
+        private String reportedPeriod;
+        private String globalApprovalStatus;
 
         private Builder() {
+        }
+
+        public static Builder aTestNviCandidate() {
+            return new Builder();
         }
 
         public Builder withIdentifier(String identifier) {
@@ -146,8 +171,40 @@ public record TestNviCandidate(String identifier,
             return this;
         }
 
+        public Builder withTotalPoints(BigDecimal totalPoints) {
+            this.totalPoints = totalPoints;
+            return this;
+        }
+
+        public Builder withPublicationTypeChannelLevelPoints(BigDecimal publicationTypeChannelLevelPoints) {
+            this.publicationTypeChannelLevelPoints = publicationTypeChannelLevelPoints;
+            return this;
+        }
+
+        public Builder withCreatorShareCount(int creatorShareCount) {
+            this.creatorShareCount = creatorShareCount;
+            return this;
+        }
+
+        public Builder withInternationalCollaborationFactor(BigDecimal internationalCollaborationFactor) {
+            this.internationalCollaborationFactor = internationalCollaborationFactor;
+            return this;
+        }
+
+        public Builder withReportedPeriod(String reportedPeriod) {
+            this.reportedPeriod = reportedPeriod;
+            return this;
+        }
+
+        public Builder withGlobalApprovalStatus(String globalApprovalStatus) {
+            this.globalApprovalStatus = globalApprovalStatus;
+            return this;
+        }
+
         public TestNviCandidate build() {
-            return new TestNviCandidate(identifier, isApplicable, modifiedDate, publicationDetails, approvals);
+            return new TestNviCandidate(identifier, isApplicable, modifiedDate, publicationDetails, approvals,
+                                        totalPoints, publicationTypeChannelLevelPoints, creatorShareCount,
+                                        internationalCollaborationFactor, reportedPeriod, globalApprovalStatus);
         }
     }
 }


### PR DESCRIPTION
Added following fields to data returned from nvi endpoint:

- `globalApprovalStatus`
- `reportedPeriod`
- `totalPoints`
- `publicationTypeChannelLevelPoints`
- `authorShareCount`
- `internationalCollaborationFactor`

`reportedPeriod` is optional, only relevant for reported nvi candidates