### PR TITLE
Catch missing graph name

### DIFF
--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
@@ -50,6 +50,7 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
     private static final String LINE_BREAK = "\n";
     private static final String ID_POINTER = "/id";
     private static final String NT_EXTENSION = ".nt";
+    private static final String MISSING_ID_NODE_IN_CONTENT_ERROR = "Missing id-node in content: {}";
 
     private final S3Client s3ResourcesClient;
     private final S3Client s3BatchesClient;
@@ -163,6 +164,7 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
     private static URI extractGraphName(JsonNode content) {
         var id = content.at(ID_POINTER);
         if (id.isMissingNode()) {
+            logger.error(MISSING_ID_NODE_IN_CONTENT_ERROR, content);
             throw new MissingIdException();
         }
         return URI.create(id.textValue() + NT_EXTENSION);

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
@@ -165,8 +165,7 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
         if (id.isMissingNode()) {
             throw new MissingIdException();
         }
-        var idString = id.textValue();
-        return URI.create(idString + NT_EXTENSION);
+        return URI.create(id.textValue() + NT_EXTENSION);
     }
 
     private String extractContent(String key) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
@@ -157,8 +157,16 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
     }
 
     private String mapToNquads(JsonNode content) {
-        var graphName = URI.create(content.at(ID_POINTER).textValue() + NT_EXTENSION);
-        return Nquads.transform(content.toString(), graphName).toString();
+        return Nquads.transform(content.toString(), extractGraphName(content)).toString();
+    }
+
+    private static URI extractGraphName(JsonNode content) {
+        var id = content.at(ID_POINTER);
+        if (id.isMissingNode()) {
+            throw new MissingIdException();
+        }
+        var idString = id.textValue();
+        return URI.create(idString + NT_EXTENSION);
     }
 
     private String extractContent(String key) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/MissingIdException.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/MissingIdException.java
@@ -1,0 +1,8 @@
+package no.sikt.nva.data.report.api.etl.transformer;
+
+public class MissingIdException extends RuntimeException {
+
+    public MissingIdException() {
+        super("Missing id node");
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/Nquads.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/Nquads.java
@@ -1,11 +1,7 @@
 package no.sikt.nva.data.report.api.etl.transformer;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URI;
-import java.nio.file.Files;
 import nva.commons.core.ioutils.IoUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.data.report.api.etl.transformer;
 
 import static java.util.UUID.randomUUID;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,6 +37,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
@@ -181,6 +183,29 @@ class BulkTransformerHandlerTest {
 
         var exception = assertThrows(RuntimeException.class, indexDocument::getDocumentIdentifier);
         assertEquals("Missing identifier in resource", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenInputJsonIsNonsense() throws IOException {
+        var documents = new ArrayList<>(createExpectedDocuments(1));
+        var node = objectMapper.createObjectNode()
+                       .set("no", objectMapper.createObjectNode());
+        var invalidDocument = new IndexDocument(randomConsumptionAttribute(), node);
+        documents.add(invalidDocument);
+        insertResourceInPersistedResourcesBucket(invalidDocument);
+        var batch = documents.stream()
+                        .map(IndexDocument::getDocumentIdentifier)
+                        .collect(Collectors.joining(System.lineSeparator()));
+        var batchKey = randomString();
+        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
+        var handler = new BulkTransformerHandler(s3ResourcesClient,
+                                                 s3BatchesClient,
+                                                 s3OutputClient,
+                                                 eventBridgeClient);
+        Executable executable = () -> handler.handleRequest(eventStream(null),
+                                                            outputStream,
+                                                            mock(Context.class));
+        assertThrows(MissingIdException.class, executable);
     }
 
     private boolean modelHasData(String contentString) {

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
@@ -32,6 +32,7 @@ import nva.commons.core.SingletonCollector;
 import nva.commons.core.StringUtils;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UnixPath;
+import nva.commons.logutils.LogUtils;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
@@ -187,6 +188,7 @@ class BulkTransformerHandlerTest {
 
     @Test
     void shouldThrowExceptionWhenInputJsonIsNonsense() throws IOException {
+        final var loggerAppender = LogUtils.getTestingAppenderForRootLogger();
         var documents = new ArrayList<>(createExpectedDocuments(1));
         var node = objectMapper.createObjectNode()
                        .set("no", objectMapper.createObjectNode());
@@ -206,6 +208,7 @@ class BulkTransformerHandlerTest {
                                                             outputStream,
                                                             mock(Context.class));
         assertThrows(MissingIdException.class, executable);
+        assertTrue(loggerAppender.getMessages().contains("Missing id-node in content"));
     }
 
     private boolean modelHasData(String contentString) {


### PR DESCRIPTION
- If the id node is missing from JSON, the graph name will be "null", this is an error
- It is unlikely that this will ever occur, but it is a valid case that is an error