### PR TITLE
Np 46278 Points for affiliation

### DIFF
--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -56,7 +56,7 @@ WHERE {
       FILTER(?modifiedDate < "__BEFORE__"^^xsd:dateTime)
 
       {
-        SELECT (COUNT(DISTINCT ?contributorId) AS ?numberOfAffiliationsForInstitution){
+        SELECT ?publicationUri ?organizationUri (COUNT(DISTINCT ?contributorId) AS ?numberOfAffiliationsForInstitution){
           ?candidate a :NviCandidate ;
                   :modifiedDate ?modifiedDate ;
                   :publicationDetails ?publicationUri ;
@@ -73,7 +73,7 @@ WHERE {
 
           FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
         }
-        GROUP BY ?publicationUri
+        GROUP BY ?publicationUri ?organizationUri
       }
       BIND(STR(ROUND((xsd:decimal(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?pointsForAffiliation)
     }

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -7,7 +7,7 @@ SELECT DISTINCT
   ?affiliationId
   ?institutionId
   ?institutionPoints
-  ?contributorPoints
+  ?pointsForAffiliation
   ?institutionApprovalStatus
   ?globalApprovalStatus
   ?reportedPeriod
@@ -75,8 +75,7 @@ WHERE {
         }
         GROUP BY ?publicationUri
       }
-      BIND(STR(round((xsd:float(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?contributorPoints)
-
+      BIND(STR(ROUND((xsd:decimal(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?pointsForAffiliation)
     }
     UNION
     {

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -7,6 +7,7 @@ SELECT DISTINCT
   ?affiliationId
   ?institutionId
   ?institutionPoints
+  ?contributorPoints
   ?institutionApprovalStatus
   ?globalApprovalStatus
   ?reportedPeriod
@@ -53,6 +54,29 @@ WHERE {
 
       FILTER(?modifiedDate >= "__AFTER__"^^xsd:dateTime)
       FILTER(?modifiedDate < "__BEFORE__"^^xsd:dateTime)
+
+      {
+        SELECT (COUNT(DISTINCT ?contributorId) AS ?numberOfAffiliationsForInstitution){
+          ?candidate a :NviCandidate ;
+                  :modifiedDate ?modifiedDate ;
+                  :publicationDetails ?publicationUri ;
+                  :approval ?approval .
+
+          ?publicationUri :contributor ?contributorId .
+                ?contributorId a :NviContributor .
+
+          ?contributorId :affiliation ?affiliationUri .
+          ?affiliationUri a ?NviOrganization .
+
+          ?approval a :Approval ;
+            :institutionId ?organizationUri .
+
+          FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
+        }
+        GROUP BY ?publicationUri
+      }
+      BIND(STR(round((xsd:float(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?contributorPoints)
+
     }
     UNION
     {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidRequestSource.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidRequestSource.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 public class ValidRequestSource implements ArgumentsProvider {
 
+    private static final String PAGE_SIZE = "100";
+    public static final String OFFSET = "0";
+
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
         return Stream.of(
@@ -19,8 +22,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "affiliation",
                              "2024-01-01T03:02:11Z",
                              "1998-01-01T05:09:32Z",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -30,8 +33,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "affiliation",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -41,8 +44,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "affiliation",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -52,8 +55,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "contributor",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -63,8 +66,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "contributor",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -74,8 +77,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "funding",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -85,8 +88,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "funding",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -96,8 +99,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "identifier",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -107,8 +110,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "identifier",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -118,8 +121,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "publication",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -129,8 +132,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "publication",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -140,8 +143,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "nvi",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             ),
@@ -151,8 +154,8 @@ public class ValidRequestSource implements ArgumentsProvider {
                              "nvi",
                              "2024-01-01",
                              "1998-01-01",
-                             "0",
-                             "10"
+                             OFFSET,
+                             PAGE_SIZE
                          )
                 )
             )

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/HeaderConstants.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/HeaderConstants.java
@@ -28,6 +28,7 @@ public final class HeaderConstants {
     public static final String CHANNEL_PRINT_ISSN = "channelPrintIssn";
     public static final String CHANNEL_LEVEL = "channelLevel";
     public static final String INSTITUTION_POINTS = "institutionPoints";
+    public static final String CONTRIBUTOR_POINTS = "contributorPoints";
     public static final String INSTITUTION_APPROVAL_STATUS = "institutionApprovalStatus";
     public static final String PUBLICATION_DATE = "publicationDate";
     public static final String TOTAL_POINTS = "totalPoints";

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/HeaderConstants.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/HeaderConstants.java
@@ -28,7 +28,7 @@ public final class HeaderConstants {
     public static final String CHANNEL_PRINT_ISSN = "channelPrintIssn";
     public static final String CHANNEL_LEVEL = "channelLevel";
     public static final String INSTITUTION_POINTS = "institutionPoints";
-    public static final String CONTRIBUTOR_POINTS = "contributorPoints";
+    public static final String POINTS_FOR_AFFILIATION = "pointsForAffiliation";
     public static final String INSTITUTION_APPROVAL_STATUS = "institutionApprovalStatus";
     public static final String PUBLICATION_DATE = "publicationDate";
     public static final String TOTAL_POINTS = "totalPoints";

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -297,6 +297,17 @@ public class TestData {
                    .build();
     }
 
+    private TestNviCandidate generateCoPublishedNviCandidate(Instant modifiedDate) {
+        var publicationDetails = TestPublicationDetails.builder()
+                                     .withId(randomUri().toString())
+                                     .withContributors(
+                                         new ArrayList<>(List.of(generateNviContributor(SOME_TOP_LEVEL_IDENTIFIER),
+                                                                 generateNviContributor("90.0.0.0"))))
+                                     .build();
+        var approvals = generateApprovals(publicationDetails);
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals).build();
+    }
+
     @SuppressWarnings("unchecked")
     private TestNviCandidate generateNonApplicableNviCandidate(Instant modifiedDate) {
         return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST).build();
@@ -350,9 +361,11 @@ public class TestData {
             var nviCandidate = generateNviCandidate(date.modifiedDate);
             var nonApplicableNviCandidate = generateNonApplicableNviCandidate(date.modifiedDate);
             var reportedCandidate = generateReportedNviCandidate(date.modifiedDate);
+            var coPublishedCandidate = generateCoPublishedNviCandidate(date.modifiedDate);
             dataSet.add(nviCandidate);
             dataSet.add(nonApplicableNviCandidate);
             dataSet.add(reportedCandidate);
+            dataSet.add(coPublishedCandidate);
         }
         return dataSet;
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -13,7 +13,7 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConsta
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_IDENTIFIER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_NAME;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_POINTS;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.POINTS_FOR_AFFILIATION;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_ROLE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_SEQUENCE_NUMBER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.DEPARTMENT_ID;
@@ -108,7 +108,7 @@ public class TestData {
                                                             CONTRIBUTOR_IDENTIFIER,
                                                             AFFILIATION_ID, INSTITUTION_ID,
                                                             INSTITUTION_POINTS,
-                                                            CONTRIBUTOR_POINTS,
+                                                            POINTS_FOR_AFFILIATION,
                                                             INSTITUTION_APPROVAL_STATUS,
                                                             GLOBAL_APPROVAL_STATUS,
                                                             REPORTED_PERIOD,

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/TestData.java
@@ -13,6 +13,7 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConsta
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_IDENTIFIER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_NAME;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_ROLE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.CONTRIBUTOR_SEQUENCE_NUMBER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.HeaderConstants.DEPARTMENT_ID;
@@ -107,6 +108,7 @@ public class TestData {
                                                             CONTRIBUTOR_IDENTIFIER,
                                                             AFFILIATION_ID, INSTITUTION_ID,
                                                             INSTITUTION_POINTS,
+                                                            CONTRIBUTOR_POINTS,
                                                             INSTITUTION_APPROVAL_STATUS,
                                                             GLOBAL_APPROVAL_STATUS,
                                                             REPORTED_PERIOD,

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -124,7 +124,8 @@ public record TestNviCandidate(String identifier,
                                  .map(TestApproval::points)
                                  .orElseThrow();
         return approvalPoints.divide(BigDecimal.valueOf(contributorCount), ROUNDING_MODE)
-                   .setScale(NVI_POINT_SCALE, ROUNDING_MODE);
+                   .setScale(NVI_POINT_SCALE, ROUNDING_MODE)
+                   .stripTrailingZeros();
     }
 
     private long countNumberOfContributorsWithTopLevelAffiliation(String topLevelOrganization) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -26,10 +26,9 @@ public record TestNviCandidate(String identifier,
                                String reportedPeriod,
                                String globalApprovalStatus) {
 
-    public static final String DELIMITER = ",";
-    public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
-    public static final int NVI_POINT_SCALE = 4;
-
+    private static final String DELIMITER = ",";
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final int NVI_POINT_SCALE = 4;
     public static Builder builder() {
         return new Builder();
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -100,13 +100,12 @@ public record TestNviCandidate(String identifier,
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor,
                                              TestNviOrganization affiliation) {
         var approval = findExpectedApproval(affiliation);
-        var calculatedContributorPoints = calculateAffiliationPoints(affiliation);
         stringBuilder.append(publicationDetails().id()).append(DELIMITER)
             .append(extractLastPathElement(contributor.id())).append(DELIMITER)
             .append(affiliation.id()).append(DELIMITER)
             .append(approval.institutionId()).append(DELIMITER)
             .append(approval.points()).append(DELIMITER)
-            .append(calculatedContributorPoints).append(DELIMITER)
+            .append(calculateAffiliationPoints(affiliation)).append(DELIMITER)
             .append(approval.approvalStatus().getValue()).append(DELIMITER)
             .append(globalApprovalStatus).append(DELIMITER)
             .append(Objects.nonNull(reportedPeriod) ? reportedPeriod : "").append(DELIMITER)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -100,7 +100,7 @@ public record TestNviCandidate(String identifier,
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor,
                                              TestNviOrganization affiliation) {
         var approval = findExpectedApproval(affiliation);
-        var calculatedContributorPoints = calculateContributorPoints(affiliation);
+        var calculatedContributorPoints = calculateAffiliationPoints(affiliation);
         stringBuilder.append(publicationDetails().id()).append(DELIMITER)
             .append(extractLastPathElement(contributor.id())).append(DELIMITER)
             .append(affiliation.id()).append(DELIMITER)
@@ -118,7 +118,7 @@ public record TestNviCandidate(String identifier,
             .append(CRLF.getString());
     }
 
-    private BigDecimal calculateContributorPoints(TestNviOrganization affiliation) {
+    private BigDecimal calculateAffiliationPoints(TestNviOrganization affiliation) {
         var topLevelOrganization = affiliation.getTopLevelOrganization();
         var contributorCount = countNumberOfContributorsWithTopLevelAffiliation(topLevelOrganization);
         var approvalPoints = Optional.ofNullable(findExpectedApproval(affiliation))


### PR DESCRIPTION
New field added to data supplied from nvi endoint: `pointsForAffiliation`
Count number of affiliations for institutions and divide `institutionPoints` on `numberOfAffiliationsForInstitution` to present `pointsForAffiliation` in result.