### PR TITLE
Np 46190 Implement ExcelFormatter, actually deliver query result in Excel file

### DIFF
--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/formatter/ExcelFormatter.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/formatter/ExcelFormatter.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.formatter;
 
+import static java.util.Objects.nonNull;
 import static nva.commons.core.StringUtils.EMPTY_STRING;
 import commons.formatter.ResponseFormatter;
 import java.io.ByteArrayOutputStream;
@@ -10,7 +11,6 @@ import java.util.Base64.Encoder;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.xlsx.Excel;
 import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.RDFNode;
 
 public class ExcelFormatter implements ResponseFormatter {
 
@@ -39,8 +39,8 @@ public class ExcelFormatter implements ResponseFormatter {
             var row = resultSet.next();
             var rowData = new ArrayList<String>();
             for (String header : headers) {
-                RDFNode cell = row.get(header);
-                rowData.add(cell != null ? cell.toString() : EMPTY_STRING);
+                var cell = row.get(header);
+                rowData.add(nonNull(cell) ? cell.toString() : EMPTY_STRING);
             }
             data.add(rowData);
         }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/formatter/ExcelFormatter.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/formatter/ExcelFormatter.java
@@ -1,13 +1,16 @@
 package no.sikt.nva.data.report.api.fetch.formatter;
 
+import static nva.commons.core.StringUtils.EMPTY_STRING;
 import commons.formatter.ResponseFormatter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Base64.Encoder;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.xlsx.Excel;
 import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.RDFNode;
 
 public class ExcelFormatter implements ResponseFormatter {
 
@@ -16,8 +19,9 @@ public class ExcelFormatter implements ResponseFormatter {
     @Override
     public String format(ResultSet resultSet) {
         var byteArrayOutputStream = new ByteArrayOutputStream();
-        //TODO: Actually use the result set to create the excel
-        var excel = Excel.fromJava(List.of("Some header"), List.of(List.of("Some data")));
+        var headers = extractHeaders(resultSet);
+        var data = extractData(headers, resultSet);
+        var excel = Excel.fromJava(headers, data);
         try {
             excel.write(byteArrayOutputStream);
         } catch (IOException e) {
@@ -27,5 +31,23 @@ public class ExcelFormatter implements ResponseFormatter {
         }
         var bytes = byteArrayOutputStream.toByteArray();
         return ENCODER.encodeToString(bytes);
+    }
+
+    private List<List<String>> extractData(List<String> headers, ResultSet resultSet) {
+        var data = new ArrayList<List<String>>();
+        while (resultSet.hasNext()) {
+            var row = resultSet.next();
+            var rowData = new ArrayList<String>();
+            for (String header : headers) {
+                RDFNode cell = row.get(header);
+                rowData.add(cell != null ? cell.toString() : EMPTY_STRING);
+            }
+            data.add(rowData);
+        }
+        return data;
+    }
+
+    private List<String> extractHeaders(ResultSet resultSet) {
+        return resultSet.getResultVars();
     }
 }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/xlsx/Excel.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/xlsx/Excel.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.data.report.api.fetch.xlsx;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/xlsx/Excel.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/xlsx/Excel.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.xlsx;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -10,13 +11,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-public final class Excel {
-
-    private final Workbook workbook;
-
-    private Excel(Workbook workbook) {
-        this.workbook = workbook;
-    }
+public record Excel(Workbook workbook) {
 
     public static Excel fromJava(List<String> headers, List<List<String>> data) {
         var excel = new Excel(new XSSFWorkbook());

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
@@ -7,7 +7,7 @@ import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedCsvFormatter.g
 import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedExcelFormatter.generateExcel;
 import static no.sikt.nva.data.report.api.fetch.formatter.ResultSorter.extractDataLines;
 import static no.sikt.nva.data.report.api.fetch.formatter.ResultSorter.sortResponse;
-import static no.sikt.nva.data.report.api.fetch.testutils.ExcelComparer.assertExcelEquals;
+import static no.sikt.nva.data.report.api.fetch.testutils.ExcelAsserter.assertEqualsInAnyOrder;
 import static nva.commons.apigateway.GatewayResponse.fromOutputStream;
 import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -149,7 +149,7 @@ class FetchDataReportTest {
         var expected = getExpectedExcel(request, testData);
         var decodedResponse = Base64.getDecoder().decode(fromOutputStream(output, String.class).getBody());
         var actual = new Excel(new XSSFWorkbook(new ByteArrayInputStream(decodedResponse)));
-        assertExcelEquals(expected, actual);
+        assertEqualsInAnyOrder(expected, actual);
     }
 
     @ParameterizedTest

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedCsvFormatter.g
 import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedExcelFormatter.generateExcel;
 import static no.sikt.nva.data.report.api.fetch.formatter.ResultSorter.extractDataLines;
 import static no.sikt.nva.data.report.api.fetch.formatter.ResultSorter.sortResponse;
+import static no.sikt.nva.data.report.api.fetch.testutils.ExcelComparer.assertExcelEquals;
 import static nva.commons.apigateway.GatewayResponse.fromOutputStream;
 import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -240,31 +241,6 @@ class FetchDataReportTest {
             case NVI -> test.getNviResponseData();
             case NVI_INSTITUTION_STATUS -> test.getNviInstitutionStatusResponseData();
         };
-    }
-
-    private void assertExcelEquals(Excel expected, Excel actual) {
-        try (var expectedWorkbook = expected.workbook(); var actualWorkbook = actual.workbook()) {
-            assertEquals(expectedWorkbook.getNumberOfSheets(), actualWorkbook.getNumberOfSheets());
-            IntStream.range(0, expectedWorkbook.getNumberOfSheets()).forEach(i -> {
-                var expectedSheet = expectedWorkbook.getSheetAt(i);
-                var actualSheet = actualWorkbook.getSheetAt(i);
-                assertEquals(expectedSheet.getPhysicalNumberOfRows(), actualSheet.getPhysicalNumberOfRows());
-
-                IntStream.range(0, expectedSheet.getPhysicalNumberOfRows()).forEach(j -> {
-                    var expectedRow = expectedSheet.getRow(j);
-                    var actualRow = actualSheet.getRow(j);
-                    assertEquals(expectedRow.getPhysicalNumberOfCells(), actualRow.getPhysicalNumberOfCells());
-
-                    IntStream.range(0, expectedRow.getPhysicalNumberOfCells()).forEach(k -> {
-                        var expectedCell = expectedRow.getCell(k);
-                        var actualCell = actualRow.getCell(k);
-                        assertEquals(expectedCell.getStringCellValue(), actualCell.getStringCellValue());
-                    });
-                });
-            });
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private List<DatePair> generateDatePairs(int numberOfDatePairs) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/formatter/ExpectedExcelFormatter.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/formatter/ExpectedExcelFormatter.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.data.report.api.fetch.formatter;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import no.sikt.nva.data.report.api.fetch.xlsx.Excel;
+
+public class ExpectedExcelFormatter {
+
+    public static Excel generateExcel(String csvString) {
+        try (CSVReader csvReader = new CSVReader(new StringReader(csvString))) {
+            var headers = Arrays.stream(csvReader.readNext()).toList();
+            var rows = csvReader.readAll().stream().map(array -> Arrays.stream(array).toList()).toList();
+
+            return Excel.fromJava(headers, rows);
+        } catch (CsvException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/formatter/ExpectedExcelFormatter.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/formatter/ExpectedExcelFormatter.java
@@ -12,7 +12,9 @@ public class ExpectedExcelFormatter {
     public static Excel generateExcel(String csvString) {
         try (CSVReader csvReader = new CSVReader(new StringReader(csvString))) {
             var headers = Arrays.stream(csvReader.readNext()).toList();
-            var rows = csvReader.readAll().stream().map(array -> Arrays.stream(array).toList()).toList();
+            var rows = csvReader.readAll().stream()
+                           .map(array -> Arrays.stream(array).toList())
+                           .toList();
 
             return Excel.fromJava(headers, rows);
         } catch (CsvException | IOException e) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ExcelAsserter.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ExcelAsserter.java
@@ -9,19 +9,18 @@ import java.util.stream.IntStream;
 import no.sikt.nva.data.report.api.fetch.xlsx.Excel;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 
-public final class ExcelComparer {
+public final class ExcelAsserter {
 
-    public static void assertExcelEquals(Excel expected, Excel actual) {
+    public static void assertEqualsInAnyOrder(Excel expected, Excel actual) {
         try (var expectedWorkbook = expected.workbook(); var actualWorkbook = actual.workbook()) {
-            assertEquals(expectedWorkbook.getNumberOfSheets(), actualWorkbook.getNumberOfSheets());
+            assertSameNumberOfSheets(expectedWorkbook, actualWorkbook);
             IntStream.range(0, expectedWorkbook.getNumberOfSheets()).forEach(i -> {
                 var expectedSheet = expectedWorkbook.getSheetAt(i);
                 var actualSheet = actualWorkbook.getSheetAt(i);
-                assertEquals(expectedSheet.getPhysicalNumberOfRows(), actualSheet.getPhysicalNumberOfRows());
-
+                assertSameNumberOfRows(expectedSheet, actualSheet);
                 assertEqualHeaders(expectedSheet, actualSheet);
-
                 var expectedData = getData(expectedSheet, expectedSheet.getPhysicalNumberOfRows());
                 var actualData = getData(actualSheet, actualSheet.getPhysicalNumberOfRows());
                 assertEquals(new HashSet<>(expectedData), new HashSet<>(actualData));
@@ -29,6 +28,14 @@ public final class ExcelComparer {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static void assertSameNumberOfRows(Sheet expectedSheet, Sheet actualSheet) {
+        assertEquals(expectedSheet.getPhysicalNumberOfRows(), actualSheet.getPhysicalNumberOfRows());
+    }
+
+    private static void assertSameNumberOfSheets(Workbook expectedWorkbook, Workbook actualWorkbook) {
+        assertEquals(expectedWorkbook.getNumberOfSheets(), actualWorkbook.getNumberOfSheets());
     }
 
     private static void assertEqualHeaders(Sheet expectedSheet, Sheet actualSheet) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ExcelComparer.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ExcelComparer.java
@@ -1,0 +1,53 @@
+package no.sikt.nva.data.report.api.fetch.testutils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import no.sikt.nva.data.report.api.fetch.xlsx.Excel;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+
+public final class ExcelComparer {
+
+    public static void assertExcelEquals(Excel expected, Excel actual) {
+        try (var expectedWorkbook = expected.workbook(); var actualWorkbook = actual.workbook()) {
+            assertEquals(expectedWorkbook.getNumberOfSheets(), actualWorkbook.getNumberOfSheets());
+            IntStream.range(0, expectedWorkbook.getNumberOfSheets()).forEach(i -> {
+                var expectedSheet = expectedWorkbook.getSheetAt(i);
+                var actualSheet = actualWorkbook.getSheetAt(i);
+                assertEquals(expectedSheet.getPhysicalNumberOfRows(), actualSheet.getPhysicalNumberOfRows());
+
+                assertEqualHeaders(expectedSheet, actualSheet);
+
+                var expectedData = getData(expectedSheet, expectedSheet.getPhysicalNumberOfRows());
+                var actualData = getData(actualSheet, actualSheet.getPhysicalNumberOfRows());
+                assertEquals(new HashSet<>(expectedData), new HashSet<>(actualData));
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void assertEqualHeaders(Sheet expectedSheet, Sheet actualSheet) {
+        var expectedHeader = expectedSheet.getRow(0);
+        var actualHeader = actualSheet.getRow(0);
+        IntStream.range(0, expectedHeader.getPhysicalNumberOfCells()).forEach(k -> {
+            var expectedCell = expectedHeader.getCell(k);
+            var actualCell = actualHeader.getCell(k);
+            assertEquals(expectedCell.getStringCellValue(), actualCell.getStringCellValue());
+        });
+    }
+
+    private static List<List<String>> getData(Sheet sheet, int endRow) {
+        return IntStream.range(1, endRow)
+                   .mapToObj(sheet::getRow)
+                   .map(row -> IntStream.range(0, row.getPhysicalNumberOfCells())
+                                   .mapToObj(row::getCell)
+                                   .map(Cell::getStringCellValue)
+                                   .collect(Collectors.toList()))
+                   .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
- Implement `ExcelFormatter`, use `ResultSet` to populate excel workbook
- Added `ExcelAsserter` to assert expected results in test `shouldReturnDataInExcelSheetWhenContentTypeIsExcel`, this does not care about the order of the data rows.
