### PR TITLE
Np 45429 fetch nvi institution report handler

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -198,24 +198,6 @@ paths:
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
                 format: binary
-        '401':
-          description: "Unauthorized"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        '404':
-          description: "Report not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Problem"
-        '500':
-          description: "Internal Server Error"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Problem"
 components:
   schemas:
     Problem:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -128,6 +128,94 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
+  /nvi/institution:
+    get:
+      description: Get institution report for nvi for current year. Supporting text/csv download according to <https://www.rfc-editor.org/rfc/rfc4180>, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet and application/ld+json.
+      security:
+        - CognitoUserPool: [
+          'https://api.nva.unit.no/scopes/backend',
+          'https://api.nva.unit.no/scopes/frontend',
+          'aws.cognito.signin.user.admin'
+        ]
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchNviInstitutionReportHandler.Arn}:live/invocations
+        responses: { }
+        httpMethod: POST
+        type: AWS_PROXY
+      responses:
+        '200':
+          description: "OK"
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: string
+              example: |
+                | ------------- | ------------- | ---------------- | 
+                | columnHeader1 | columnHeader2 | columnHeaders... |
+                | ------------- | ------------- | ---------------- |
+                | row1 value1   | row1 value2   | row1 value3      |
+                | row2 value1   | row2 value2   | row2 value3      |
+                | row... value1 | row... value2 | row... value3    |
+                | ------------- | ------------- | ---------------- |
+            text/csv:
+              schema:
+                type: string
+                format: string
+              example: |
+                columnHeader1,columnHeader2,columnHeaders...
+                "row1 value1","row1 value2","row1 value3"
+                "row2 value1","row2 value2","row2 value3"
+                "row... value1","row... value2""row... value3"
+            application/ld+json:
+              schema:
+                type: object
+              example: |
+                {
+                  "@context": "https://nva.sikt.no/report/type/context",
+                  "results": [
+                    {
+                      "columnName1": "Row 1 Value 1",
+                      "columnName2": "Row 1 Value 2",
+                      "columnName...": "Row 1 Value..."
+                    },
+                    {
+                      "columnName1": "Row 2 Value 1",
+                      "columnName2": "Row 2 Value 2",
+                      "columnName...": "Row 2 Value..."
+                    },
+                    {
+                      "columnName1": "Row... Value 1",
+                      "columnName2": "Row... Value 2",
+                      "columnName...": "Row... Value..."
+                    }
+                  ]
+                }
+            application/vnd.ms-excel:
+              schema:
+                format: binary
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                format: binary
+        '401':
+          description: "Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        '404':
+          description: "Report not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        '500':
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
 components:
   schemas:
     Problem:

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -1,0 +1,33 @@
+package no.sikt.nva.data.report.api.fetch;
+
+import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
+import static com.google.common.net.MediaType.OOXML_SHEET;
+import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_CSV;
+import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_PLAIN;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.google.common.net.MediaType;
+import java.util.List;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.RequestInfo;
+
+public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
+
+    public FetchNviInstitutionReport() {
+        super(Void.class);
+    }
+
+    @Override
+    protected List<MediaType> listSupportedMediaTypes() {
+        return List.of(TEXT_CSV, TEXT_PLAIN, MICROSOFT_EXCEL, OOXML_SHEET);
+    }
+
+    @Override
+    protected String processInput(Void unused, RequestInfo requestInfo, Context context) {
+        return null;
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(Void unused, String o) {
+        return 200;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -1,0 +1,37 @@
+package no.sikt.nva.data.report.api.fetch;
+
+import static nva.commons.apigateway.GatewayResponse.fromOutputStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import no.sikt.nva.data.report.api.fetch.testutils.requests.FetchNviInstitutionReportRequest;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class FetchNviInstitutionReportTest extends LocalFusekiTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain", "text/csv", "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"})
+    void shouldHandleRequest(String contentType) throws IOException {
+        var handler = new FetchNviInstitutionReport();
+        var output = new ByteArrayOutputStream();
+        var request = new FetchNviInstitutionReportRequest(contentType);
+        var input = generateHandlerRequest(request);
+        handler.handleRequest(input, output, new FakeContext());
+        var response = fromOutputStream(output, String.class);
+        assertEquals(200, response.getStatusCode());
+    }
+
+    private static InputStream generateHandlerRequest(FetchNviInstitutionReportRequest request)
+        throws JsonProcessingException {
+        return new HandlerRequestBuilder<InputStream>(JsonUtils.dtoObjectMapper)
+                   .withHeaders(request.acceptHeader())
+                   .build();
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/LocalFusekiTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/LocalFusekiTest.java
@@ -1,0 +1,74 @@
+package no.sikt.nva.data.report.api.fetch;
+
+import commons.db.DatabaseConnection;
+import commons.db.GraphStoreProtocolConnection;
+import java.io.StringWriter;
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.IntStream;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.TestData.DatePair;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.PublicationDate;
+import no.sikt.nva.data.report.testing.utils.FusekiTestingServer;
+import nva.commons.core.Environment;
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+
+public abstract class LocalFusekiTest {
+
+    static final String GSP_ENDPOINT = "/gsp";
+    static final URI GRAPH = URI.create("https://example.org/graph");
+    static FusekiServer server;
+    static DatabaseConnection databaseConnection;
+
+    @BeforeAll
+    static void setup() {
+        var dataSet = DatasetFactory.createTxnMem();
+        server = FusekiTestingServer.init(dataSet, GSP_ENDPOINT);
+        var url = server.serverURL();
+        var queryPath = new Environment().readEnv("QUERY_PATH");
+        databaseConnection = new GraphStoreProtocolConnection(url, url, queryPath);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        server.stop();
+    }
+
+    @AfterEach
+    void clearDatabase() {
+        try {
+            databaseConnection.delete(GRAPH);
+        } catch (Exception e) {
+            // Necessary to avoid case where we hve already deleted the graph
+            catchExpectedExceptionsExceptHttpException(e);
+        }
+    }
+
+    String toTriples(Model model) {
+        var stringWriter = new StringWriter();
+        RDFDataMgr.write(stringWriter, model, Lang.NTRIPLES);
+        return stringWriter.toString();
+    }
+
+    List<DatePair> generateDatePairs(int numberOfDatePairs) {
+        return IntStream.range(0, numberOfDatePairs)
+                   .mapToObj(i -> new DatePair(new PublicationDate("2024", "02", "02"),
+                                               Instant.now().minus(100, ChronoUnit.DAYS)))
+                   .toList();
+    }
+
+    private static void catchExpectedExceptionsExceptHttpException(Exception e) {
+        if (!(e instanceof HttpException)) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/BadRequestProvider.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/BadRequestProvider.java
@@ -2,6 +2,7 @@ package no.sikt.nva.data.report.api.fetch.testutils;
 
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_PLAIN;
 import java.util.stream.Stream;
+import no.sikt.nva.data.report.api.fetch.testutils.requests.FetchDataReportRequest;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -13,13 +14,14 @@ public class BadRequestProvider implements ArgumentsProvider {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
         return Stream.of(
             Arguments.of(Named.of("Bad report type",
-                                  new TestingRequest(TEXT_PLAIN.toString(),
-                                                     "weird",
-                                                     "2012-01-01",
-                                                     "2023-12-31", "0",
-                                                     "10"))),
+                                  new FetchDataReportRequest(
+                                      TEXT_PLAIN.toString(),
+                                      "weird",
+                                      "2012-01-01",
+                                      "2023-12-31", "0",
+                                      "10"))),
             Arguments.of(Named.of("Bad before date",
-                                  new TestingRequest(
+                                  new FetchDataReportRequest(
                                       TEXT_PLAIN.toString(),
                                       "identifier",
                                       "2012-0101",
@@ -27,34 +29,34 @@ public class BadRequestProvider implements ArgumentsProvider {
                                       "10"))
             ),
             Arguments.of(Named.of("Bad after date",
-                                  new TestingRequest(TEXT_PLAIN.toString(),
-                                                     "identifier",
-                                                     "2012-01-01",
-                                                     "2023-1231",
-                                                     "0",
-                                                     "10"))),
+                                  new FetchDataReportRequest(TEXT_PLAIN.toString(),
+                                                             "identifier",
+                                                             "2012-01-01",
+                                                             "2023-1231",
+                                                             "0",
+                                                             "10"))),
             Arguments.of(Named.of("Before is before after date",
-                                  new TestingRequest(TEXT_PLAIN.toString(),
-                                                     "identifier",
-                                                     "2019-01-01",
-                                                     "2020-12-31",
-                                                     "0",
-                                                     "10"))
+                                  new FetchDataReportRequest(TEXT_PLAIN.toString(),
+                                                             "identifier",
+                                                             "2019-01-01",
+                                                             "2020-12-31",
+                                                             "0",
+                                                             "10"))
             ),
             Arguments.of(Named.of("Offset is negative number",
-                                  new TestingRequest(TEXT_PLAIN.toString(),
-                                                     "identifier",
-                                                     "2020-01-01",
-                                                     "2020-12-31",
-                                                     "-10",
-                                                     "10"))),
+                                  new FetchDataReportRequest(TEXT_PLAIN.toString(),
+                                                             "identifier",
+                                                             "2020-01-01",
+                                                             "2020-12-31",
+                                                             "-10",
+                                                             "10"))),
             Arguments.of(Named.of("Offset is negative number",
-                                  new TestingRequest(TEXT_PLAIN.toString(),
-                                                     "identifier",
-                                                     "2020-01-01",
-                                                     "2020-12-31",
-                                                     "10",
-                                                     "-10"))
+                                  new FetchDataReportRequest(TEXT_PLAIN.toString(),
+                                                             "identifier",
+                                                             "2020-01-01",
+                                                             "2020-12-31",
+                                                             "10",
+                                                             "-10"))
             )
         );
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidExcelRequestSource.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidExcelRequestSource.java
@@ -3,6 +3,7 @@ package no.sikt.nva.data.report.api.fetch.testutils;
 import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
 import static com.google.common.net.MediaType.OOXML_SHEET;
 import java.util.stream.Stream;
+import no.sikt.nva.data.report.api.fetch.testutils.requests.FetchDataReportRequest;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,7 +18,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
         return Stream.of(
             Arguments.of(
-                Named.of("affiliation — application/vnd.ms-excel", new TestingRequest(
+                Named.of("affiliation — application/vnd.ms-excel", new FetchDataReportRequest(
                              MICROSOFT_EXCEL.toString(),
                              "affiliation",
                              "2024-01-01",
@@ -29,7 +30,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
             ),
             Arguments.of(
                 Named.of("affiliation — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                         new TestingRequest(
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "affiliation",
                              "2024-01-01",
@@ -40,7 +41,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("contributor — application/vnd.ms-excel", new TestingRequest(
+                Named.of("contributor — application/vnd.ms-excel", new FetchDataReportRequest(
                              MICROSOFT_EXCEL.toString(),
                              "contributor",
                              "2024-01-01",
@@ -52,7 +53,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
             ),
             Arguments.of(
                 Named.of("contributor — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                         new TestingRequest(
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "contributor",
                              "2024-01-01",
@@ -63,7 +64,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("funding — application/vnd.ms-excel", new TestingRequest(
+                Named.of("funding — application/vnd.ms-excel", new FetchDataReportRequest(
                              MICROSOFT_EXCEL.toString(),
                              "funding",
                              "2024-01-01",
@@ -75,7 +76,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
             ),
             Arguments.of(
                 Named.of("funding — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                         new TestingRequest(
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "funding",
                              "2024-01-01",
@@ -86,7 +87,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("identifier — application/vnd.ms-excel", new TestingRequest(
+                Named.of("identifier — application/vnd.ms-excel", new FetchDataReportRequest(
                              MICROSOFT_EXCEL.toString(),
                              "identifier",
                              "2024-01-01",
@@ -98,7 +99,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
             ),
             Arguments.of(
                 Named.of("identifier — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                         new TestingRequest(
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "identifier",
                              "2024-01-01",
@@ -109,7 +110,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("publication — application/vnd.ms-excel", new TestingRequest(
+                Named.of("publication — application/vnd.ms-excel", new FetchDataReportRequest(
                              MICROSOFT_EXCEL.toString(),
                              "publication",
                              "2024-01-01",
@@ -121,7 +122,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
             ),
             Arguments.of(
                 Named.of("publication — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                         new TestingRequest(
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "publication",
                              "2024-01-01",
@@ -131,7 +132,7 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                          )
                 )
             ),
-            Arguments.of(Named.of("nvi — application/vnd.ms-excel", new TestingRequest(
+            Arguments.of(Named.of("nvi — application/vnd.ms-excel", new FetchDataReportRequest(
                                       MICROSOFT_EXCEL.toString(),
                                       "nvi",
                                       "2024-01-01",
@@ -142,7 +143,8 @@ public class ValidExcelRequestSource implements ArgumentsProvider {
                          )
             ),
             Arguments.of(
-                Named.of("nvi — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", new TestingRequest(
+                Named.of("nvi — application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                         new FetchDataReportRequest(
                              OOXML_SHEET.toString(),
                              "nvi",
                              "2024-01-01",

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidRequestSource.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/ValidRequestSource.java
@@ -3,6 +3,7 @@ package no.sikt.nva.data.report.api.fetch.testutils;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_CSV;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_PLAIN;
 import java.util.stream.Stream;
+import no.sikt.nva.data.report.api.fetch.testutils.requests.FetchDataReportRequest;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,7 +18,7 @@ public class ValidRequestSource implements ArgumentsProvider {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
         return Stream.of(
             Arguments.of(
-                Named.of("Allows full datetime", new TestingRequest(
+                Named.of("Allows full datetime", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "affiliation",
                              "2024-01-01T03:02:11Z",
@@ -28,7 +29,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("affiliation — text/csv", new TestingRequest(
+                Named.of("affiliation — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "affiliation",
                              "2024-01-01",
@@ -39,7 +40,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("affiliation — text/plain", new TestingRequest(
+                Named.of("affiliation — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "affiliation",
                              "2024-01-01",
@@ -50,7 +51,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("contributor — text/csv", new TestingRequest(
+                Named.of("contributor — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "contributor",
                              "2024-01-01",
@@ -61,7 +62,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("contributor — text/plain", new TestingRequest(
+                Named.of("contributor — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "contributor",
                              "2024-01-01",
@@ -72,7 +73,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("funding — text/csv", new TestingRequest(
+                Named.of("funding — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "funding",
                              "2024-01-01",
@@ -83,7 +84,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("funding — text/plain", new TestingRequest(
+                Named.of("funding — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "funding",
                              "2024-01-01",
@@ -94,7 +95,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("identifier — text/csv", new TestingRequest(
+                Named.of("identifier — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "identifier",
                              "2024-01-01",
@@ -105,7 +106,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("identifier — text/plain", new TestingRequest(
+                Named.of("identifier — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "identifier",
                              "2024-01-01",
@@ -116,7 +117,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("publication — text/csv", new TestingRequest(
+                Named.of("publication — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "publication",
                              "2024-01-01",
@@ -127,7 +128,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("publication — text/plain", new TestingRequest(
+                Named.of("publication — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "publication",
                              "2024-01-01",
@@ -138,7 +139,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("nvi — text/csv", new TestingRequest(
+                Named.of("nvi — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "nvi",
                              "2024-01-01",
@@ -149,7 +150,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("nvi — text/plain", new TestingRequest(
+                Named.of("nvi — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "nvi",
                              "2024-01-01",
@@ -160,7 +161,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("nvi institution report — text/csv", new TestingRequest(
+                Named.of("nvi institution report — text/csv", new FetchDataReportRequest(
                              TEXT_CSV.toString(),
                              "nvi-institution-status",
                              "2024-01-01",
@@ -171,7 +172,7 @@ public class ValidRequestSource implements ArgumentsProvider {
                 )
             ),
             Arguments.of(
-                Named.of("nvi institution report — text/plain", new TestingRequest(
+                Named.of("nvi institution report — text/plain", new FetchDataReportRequest(
                              TEXT_PLAIN.toString(),
                              "nvi-institution-status",
                              "2024-01-01",

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchDataReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchDataReportRequest.java
@@ -1,13 +1,13 @@
-package no.sikt.nva.data.report.api.fetch.testutils;
+package no.sikt.nva.data.report.api.fetch.testutils.requests;
 
 import java.util.Map;
 
-public record TestingRequest(String accept,
-                             String reportType,
-                             String before,
-                             String after,
-                             String offset,
-                             String pageSize) {
+public record FetchDataReportRequest(String accept,
+                                     String reportType,
+                                     String before,
+                                     String after,
+                                     String offset,
+                                     String pageSize) {
 
     public Map<String, String> queryParameters() {
         return Map.of(

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
@@ -1,0 +1,10 @@
+package no.sikt.nva.data.report.api.fetch.testutils.requests;
+
+import java.util.Map;
+
+public record FetchNviInstitutionReportRequest(String accept) {
+
+    public Map<String, String> acceptHeader() {
+        return Map.of("Accept", accept);
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -315,6 +315,35 @@ Resources:
             Method: get
             RestApiId: !Ref DataReportApi
 
+  # ---- Handler ----
+  FetchNviInstitutionReportHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: report-api
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - !Ref LambdaSubnet1
+          - !Ref LambdaSubnet2
+      Policies:
+        - VPCAccessPolicy: { }
+      Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      Timeout: 600
+      MemorySize: 1536
+      AutoPublishAlias: live
+      Environment:
+        Variables:
+          ALLOWED_ORIGIN: '*'
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /nvi/institution
+            Method: get
+            RestApiId: !Ref DataReportApi
+
   DataLoadingHandler:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
First part of moving nvi institution report to its own handler.
- Added `FetchNviInstitutionReport` which does noting atm. Supports media types for csv and excel.

Some refactoring in tests:
- Renamed `TestingRequest` to `FetchDataReportRequest`
- Added `FetchNviInstitutionReportRequest`
- Created `LocalFusekiTest` for setting up local fuseki servers i both test classes