### PR TITLE
Np 45429 Nvi institution report, log requested year and topLevelOrg

### DIFF
--- a/report-api/build.gradle
+++ b/report-api/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.4'
 
     testImplementation libs.jena.fuseki
+    testImplementation libs.bundles.logging
     testImplementation(project(':testing-utils'))
     testImplementation 'com.opencsv:opencsv:5.9'
     testImplementation(libs.nva.testutils) {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.MediaType;
 import commons.db.GraphStoreProtocolConnection;
 import commons.formatter.ResponseFormatter;
+import java.net.URI;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.formatter.CsvFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
@@ -20,12 +21,15 @@ import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
 
-    public static final String ACCEPT = "Accept";
-    public static final String NVI_INSTITUTION_STATUS_SPARQL = "nvi-institution-status";
-    public static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
+    private static final Logger logger = LoggerFactory.getLogger(FetchNviInstitutionReport.class);
+    private static final String ACCEPT = "Accept";
+    private static final String NVI_INSTITUTION_STATUS_SPARQL = "nvi-institution-status";
+    private static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
     private final QueryService queryService;
 
     @JacocoGenerated
@@ -48,6 +52,10 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
         validateAccessRights(requestInfo);
         var reportFormat = ReportFormat.fromMediaType(requestInfo.getHeader(ACCEPT));
         var reportingYear = requestInfo.getPathParameter(PATH_PARAMETER_REPORTING_YEAR);
+        var topLevelOrganization = requestInfo.getTopLevelOrgCristinId().map(URI::toString).orElse(
+            "UnknownRequestTopLevelOrganization");
+        logger.info("NVI institution status report requested for organization: {}, reporting year: {}",
+                    topLevelOrganization, reportingYear);
         var result = queryService.getResult(NVI_INSTITUTION_STATUS_SPARQL, getFormatter(reportFormat));
         setIsBase64EncodedIfReportFormatExcel(reportFormat);
         return result;

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -25,6 +25,7 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
 
     public static final String ACCEPT = "Accept";
     public static final String NVI_INSTITUTION_STATUS_SPARQL = "nvi-institution-status";
+    public static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
     private final QueryService queryService;
 
     @JacocoGenerated
@@ -46,6 +47,7 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
     protected String processInput(Void unused, RequestInfo requestInfo, Context context) throws UnauthorizedException {
         validateAccessRights(requestInfo);
         var reportFormat = ReportFormat.fromMediaType(requestInfo.getHeader(ACCEPT));
+        var reportingYear = requestInfo.getPathParameter(PATH_PARAMETER_REPORTING_YEAR);
         var result = queryService.getResult(NVI_INSTITUTION_STATUS_SPARQL, getFormatter(reportFormat));
         setIsBase64EncodedIfReportFormatExcel(reportFormat);
         return result;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -43,6 +43,7 @@ import org.zalando.problem.Status;
 public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     public static final AccessRight SOME_ACCESS_RIGHT_THAT_IS_NOT_MANAGE_NVI = AccessRight.SUPPORT;
+    public static final String SOME_YEAR = "2023";
     private FetchNviInstitutionReport handler;
 
     @BeforeEach
@@ -52,7 +53,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     @Test
     void shouldReturn401WhenUserDoesNotHaveManageNviAccessRight() throws IOException {
-        var request = new FetchNviInstitutionReportRequest("2023", "text/plain");
+        var request = new FetchNviInstitutionReportRequest(SOME_YEAR, "text/plain");
         var unAuthorizedRequest = generateHandlerRequest(request, SOME_ACCESS_RIGHT_THAT_IS_NOT_MANAGE_NVI,
                                                          randomUri());
         var output = new ByteArrayOutputStream();
@@ -67,20 +68,19 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     @Test
     void shouldExtractAndLogPathParameterReportingYear() throws IOException {
         var logAppender = LogUtils.getTestingAppenderForRootLogger();
-        var year = "2023";
-        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(year, "text/plain"),
+        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(SOME_YEAR, "text/plain"),
                                              AccessRight.MANAGE_NVI, randomUri());
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);
-        assertTrue(logAppender.getMessages().contains("reporting year: " + year));
+        assertTrue(logAppender.getMessages().contains("reporting year: " + SOME_YEAR));
     }
 
     @Test
     void shouldLogRequestingUsersTopLevelOrganization() throws IOException {
         var logAppender = LogUtils.getTestingAppenderForRootLogger();
         var topLevelCristinOrgId = randomUri();
-        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest("2023", "text/plain"),
+        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(SOME_YEAR, "text/plain"),
                                              AccessRight.MANAGE_NVI, topLevelCristinOrgId);
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
@@ -142,13 +142,13 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     }
 
     private static Stream<Arguments> fetchNviInstitutionReportRequestProvider() {
-        return Stream.of(Arguments.of(new FetchNviInstitutionReportRequest("2023", "text/plain")),
-                         Arguments.of(new FetchNviInstitutionReportRequest("2023", "text/csv")));
+        return Stream.of(Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, "text/plain")),
+                         Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, "text/csv")));
     }
 
     private static Stream<Arguments> fetchNviInstitutionReportExcelRequestProvider() {
-        return Stream.of(Arguments.of(new FetchNviInstitutionReportRequest("2023", "application/vnd.ms-excel")),
-                         Arguments.of(new FetchNviInstitutionReportRequest("2023",
+        return Stream.of(Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, "application/vnd.ms-excel")),
+                         Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR,
                                                                            "application/vnd"
                                                                            + ".openxmlformats-officedocument"
                                                                            + ".spreadsheetml.sheet")));

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -69,7 +69,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
         var logAppender = LogUtils.getTestingAppenderForRootLogger();
         var year = "2023";
         var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(year, "text/plain"),
-                                             SOME_ACCESS_RIGHT_THAT_IS_NOT_MANAGE_NVI, randomUri());
+                                             AccessRight.MANAGE_NVI, randomUri());
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);
@@ -81,7 +81,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
         var logAppender = LogUtils.getTestingAppenderForRootLogger();
         var topLevelCristinOrgId = randomUri();
         var request = generateHandlerRequest(new FetchNviInstitutionReportRequest("2023", "text/plain"),
-                                             SOME_ACCESS_RIGHT_THAT_IS_NOT_MANAGE_NVI, topLevelCristinOrgId);
+                                             AccessRight.MANAGE_NVI, topLevelCristinOrgId);
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
@@ -2,7 +2,12 @@ package no.sikt.nva.data.report.api.fetch.testutils.requests;
 
 import java.util.Map;
 
-public record FetchNviInstitutionReportRequest(String accept) {
+public record FetchNviInstitutionReportRequest(String year,
+                                               String accept) {
+
+    public Map<String, String> pathParameters() {
+        return Map.of("year", year);
+    }
 
     public Map<String, String> acceptHeader() {
         return Map.of("Accept", accept);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
@@ -2,11 +2,11 @@ package no.sikt.nva.data.report.api.fetch.testutils.requests;
 
 import java.util.Map;
 
-public record FetchNviInstitutionReportRequest(String year,
+public record FetchNviInstitutionReportRequest(String reportingYear,
                                                String accept) {
 
     public Map<String, String> pathParameters() {
-        return Map.of("year", year);
+        return Map.of("reportingYear", reportingYear);
     }
 
     public Map<String, String> acceptHeader() {


### PR DESCRIPTION
- Take in `reportingYear` as path parameter, this allows reporting handler be "agnostic" to which period is open etc (nvi logic). It also supports possibility of multiple open periods which one can fetch an institution report for.
- For now, just logging `reportingYear` and requesting users `topLevelCristinOrg`, these will be used in the sparql query for the report.