### PR TITLE
Np 45429 Nvi data report, refactor reporting period

### DIFF
--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -30,7 +30,11 @@ WHERE {
         :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
 
       OPTIONAL {
-        ?candidate :reportedPeriod ?reportedPeriod .
+        ?candidate :reported ?reported ;
+                   :reportingPeriod ?reportingPeriod .
+        ?reportingPeriod a :ReportingPeriod ;
+                         :year ?reportedYear .
+        BIND(IF(?reported = true, ?reportedYear, "NotReported") AS ?reportedPeriod)
       }
 
       BIND(STR(?publicationUri) AS ?publicationId)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -171,13 +171,13 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     private String getExpected(FetchNviInstitutionReportRequest request, TestData test) {
         var reportFormat = getReportFormat(request);
-        var data = test.getNviInstitutionStatusResponseData(SOME_YEAR);
+        var data = test.getNviInstitutionStatusResponseData();
         return ReportFormat.CSV.equals(reportFormat)
                    ? data
                    : generateTable(data);
     }
 
     private Excel getExpectedExcel(TestData test) {
-        return generateExcel(test.getNviInstitutionStatusResponseData(SOME_YEAR));
+        return generateExcel(test.getNviInstitutionStatusResponseData());
     }
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -171,13 +171,13 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     private String getExpected(FetchNviInstitutionReportRequest request, TestData test) {
         var reportFormat = getReportFormat(request);
-        var data = test.getNviInstitutionStatusResponseData();
+        var data = test.getNviInstitutionStatusResponseData(SOME_YEAR);
         return ReportFormat.CSV.equals(reportFormat)
                    ? data
                    : generateTable(data);
     }
 
     private Excel getExpectedExcel(TestData test) {
-        return generateExcel(test.getNviInstitutionStatusResponseData());
+        return generateExcel(test.getNviInstitutionStatusResponseData(SOME_YEAR));
     }
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -68,9 +68,9 @@ public final class NviTestData {
     static List<TestNviCandidate> generateNviData(List<DatePair> dates) {
         var dataSet = new ArrayList<TestNviCandidate>();
         for (DatePair date : dates) {
-            var nviCandidate = generateNviCandidate(date.modifiedDate());
+            var nviCandidate = generateNviCandidate(date.modifiedDate(), date.publicationDate().year());
             var nonApplicableNviCandidate = generateNonApplicableNviCandidate(date.modifiedDate());
-            var reportedCandidate = generateReportedNviCandidate(date.modifiedDate());
+            var reportedCandidate = generateReportedNviCandidate(date.modifiedDate(), date.publicationDate().year());
             var coPublishedCandidate = generateCoPublishedNviCandidate(date.modifiedDate());
             dataSet.add(nviCandidate);
             dataSet.add(nonApplicableNviCandidate);
@@ -80,17 +80,17 @@ public final class NviTestData {
         return dataSet;
     }
 
-    private static TestNviCandidate generateNviCandidate(Instant modifiedDate) {
+    private static TestNviCandidate generateNviCandidate(Instant modifiedDate, String reportingYear) {
         var publicationDetails = generatePublicationDetails();
         var approvals = generateApprovals(publicationDetails);
-        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals).build();
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals, reportingYear).build();
     }
 
-    private static TestNviCandidate generateReportedNviCandidate(Instant modifiedDate) {
+    private static TestNviCandidate generateReportedNviCandidate(Instant modifiedDate, String reportingYear) {
         var publicationDetails = generatePublicationDetails();
         var approvals = generateApprovals(publicationDetails);
-        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals)
-                   .withReportedPeriod("2021")
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals, reportingYear)
+                   .withReported(true)
                    .build();
     }
 
@@ -102,12 +102,12 @@ public final class NviTestData {
                                                                  generateNviContributor("90.0.0.0"))))
                                      .build();
         var approvals = generateApprovals(publicationDetails);
-        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals).build();
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals, "2023").build();
     }
 
     @SuppressWarnings("unchecked")
     private static TestNviCandidate generateNonApplicableNviCandidate(Instant modifiedDate) {
-        return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST).build();
+        return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST, "2023").build();
     }
 
     private static TestPublicationDetails generatePublicationDetails() {
@@ -150,7 +150,7 @@ public final class NviTestData {
 
     private static Builder getCandidateBuilder(boolean isApplicable, Instant modifiedDate,
                                                TestPublicationDetails publicationDetails,
-                                               List<TestApproval> approvals) {
+                                               List<TestApproval> approvals, String reportingPeriod) {
         return TestNviCandidate.builder()
                    .withIsApplicable(isApplicable)
                    .withIdentifier(UUID.randomUUID().toString())
@@ -161,7 +161,9 @@ public final class NviTestData {
                    .withInternationalCollaborationFactor(BigDecimal.ONE)
                    .withGlobalApprovalStatus(ApprovalStatus.PENDING.getValue())
                    .withPublicationTypeChannelLevelPoints(randomBigDecimal())
-                   .withTotalPoints(randomBigDecimal());
+                   .withTotalPoints(randomBigDecimal())
+                   .withReportingPeriod(reportingPeriod);
+
     }
 
     private static int countCombinationsOfCreatorsAndAffiliations(TestPublicationDetails publicationDetails) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -69,9 +69,11 @@ public final class NviTestData {
         var dataSet = new ArrayList<TestNviCandidate>();
         for (DatePair date : dates) {
             var nviCandidate = generateNviCandidate(date.modifiedDate(), date.publicationDate().year());
-            var nonApplicableNviCandidate = generateNonApplicableNviCandidate(date.modifiedDate());
+            var nonApplicableNviCandidate = generateNonApplicableNviCandidate(date.modifiedDate(),
+                                                                              date.publicationDate().year());
             var reportedCandidate = generateReportedNviCandidate(date.modifiedDate(), date.publicationDate().year());
-            var coPublishedCandidate = generateCoPublishedNviCandidate(date.modifiedDate());
+            var coPublishedCandidate = generateCoPublishedNviCandidate(date.modifiedDate(),
+                                                                       date.publicationDate().year());
             dataSet.add(nviCandidate);
             dataSet.add(nonApplicableNviCandidate);
             dataSet.add(reportedCandidate);
@@ -94,7 +96,7 @@ public final class NviTestData {
                    .build();
     }
 
-    private static TestNviCandidate generateCoPublishedNviCandidate(Instant modifiedDate) {
+    private static TestNviCandidate generateCoPublishedNviCandidate(Instant modifiedDate, String reportingYear) {
         var publicationDetails = TestPublicationDetails.builder()
                                      .withId(randomUri().toString())
                                      .withContributors(
@@ -102,12 +104,12 @@ public final class NviTestData {
                                                                  generateNviContributor("90.0.0.0"))))
                                      .build();
         var approvals = generateApprovals(publicationDetails);
-        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals, "2023").build();
+        return getCandidateBuilder(true, modifiedDate, publicationDetails, approvals, reportingYear).build();
     }
 
     @SuppressWarnings("unchecked")
-    private static TestNviCandidate generateNonApplicableNviCandidate(Instant modifiedDate) {
-        return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST, "2023").build();
+    private static TestNviCandidate generateNonApplicableNviCandidate(Instant modifiedDate, String reportingYear) {
+        return getCandidateBuilder(false, modifiedDate, generatePublicationDetails(), Collections.EMPTY_LIST, reportingYear).build();
     }
 
     private static TestPublicationDetails generatePublicationDetails() {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
-import static java.util.Objects.nonNull;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.Constants.ONTOLOGY_BASE_URI;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
@@ -26,7 +25,8 @@ public class CandidateGenerator extends TripleBasedBuilder {
     private static final Property CREATOR_SHARE_COUNT = new PropertyImpl(ONTOLOGY_BASE_URI + "creatorShareCount");
     private static final Property INTERNATIONAL_COLLABORATION_FACTOR = new PropertyImpl(
         ONTOLOGY_BASE_URI + "internationalCollaborationFactor");
-    private static final Property REPORTED_PERIOD = new PropertyImpl(ONTOLOGY_BASE_URI + "reportedPeriod");
+    private static final Property REPORTED = new PropertyImpl(ONTOLOGY_BASE_URI + "reported");
+    private static final Property REPORTING_PERIOD = new PropertyImpl(ONTOLOGY_BASE_URI + "reportingPeriod");
     private static final Property GLOBAL_APPROVAL_STATUS = new PropertyImpl(ONTOLOGY_BASE_URI + "globalApprovalStatus");
     private final Model model;
     private final Resource subject;
@@ -48,6 +48,12 @@ public class CandidateGenerator extends TripleBasedBuilder {
     public CandidateGenerator withApproval(ApprovalGenerator approval) {
         model.add(subject, APPROVAL, approval.getSubject());
         model.add(approval.build());
+        return this;
+    }
+
+    public CandidateGenerator withReportingPeriod(ReportingPeriodGenerator reportingPeriod) {
+        model.add(subject, REPORTING_PERIOD, reportingPeriod.getSubject());
+        model.add(reportingPeriod.build());
         return this;
     }
 
@@ -78,10 +84,8 @@ public class CandidateGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public CandidateGenerator withReportedPeriod(String reportedPeriod) {
-        if (nonNull(reportedPeriod)) {
-            model.add(subject, REPORTED_PERIOD, model.createTypedLiteral(reportedPeriod));
-        }
+    public CandidateGenerator withReported(boolean reported) {
+        model.add(subject, REPORTED, model.createTypedLiteral(reported));
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ReportingPeriodGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ReportingPeriodGenerator.java
@@ -1,0 +1,42 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
+
+import static java.util.Objects.nonNull;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+
+public class ReportingPeriodGenerator extends TripleBasedBuilder {
+
+    private static final Property YEAR = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "year");
+    private static final String REPORTING_PERIOD = "ReportingPeriod";
+
+    private final Model model;
+    private final Resource subject;
+
+    public ReportingPeriodGenerator() {
+        this.model = ModelFactory.createDefaultModel();
+        this.subject = model.createResource();
+        model.add(subject, TYPE, model.createResource(Constants.ONTOLOGY_BASE_URI + REPORTING_PERIOD));
+    }
+
+    public ReportingPeriodGenerator withYear(String year) {
+        if (nonNull(year)) {
+            model.add(subject, YEAR, model.createTypedLiteral(year));
+        }
+        return this;
+    }
+
+    @Override
+    public Model build() {
+        return model;
+    }
+
+    @Override
+    public Resource getSubject() {
+        return subject;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -5,11 +5,11 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.CandidateGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.PublicationDetailsGenerator;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ReportingPeriodGenerator;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
 import nva.commons.core.paths.UriWrapper;
 import org.apache.jena.rdf.model.Model;
@@ -23,7 +23,8 @@ public record TestNviCandidate(String identifier,
                                BigDecimal publicationTypeChannelLevelPoints,
                                int creatorShareCount,
                                BigDecimal internationalCollaborationFactor,
-                               String reportedPeriod,
+                               boolean reported,
+                               String reportingPeriod,
                                String globalApprovalStatus) {
 
     private static final String DELIMITER = ",";
@@ -88,7 +89,8 @@ public record TestNviCandidate(String identifier,
                    .withPublicationTypeChannelLevelPoints(publicationTypeChannelLevelPoints.toString())
                    .withCreatorShareCount(String.valueOf(creatorShareCount))
                    .withInternationalCollaborationFactor(internationalCollaborationFactor.toString())
-                   .withReportedPeriod(reportedPeriod)
+                   .withReported(reported)
+                   .withReportingPeriod(new ReportingPeriodGenerator().withYear(reportingPeriod))
                    .withGlobalApprovalStatus(globalApprovalStatus);
     }
 
@@ -108,7 +110,7 @@ public record TestNviCandidate(String identifier,
             .append(calculateAffiliationPoints(affiliation)).append(DELIMITER)
             .append(approval.approvalStatus().getValue()).append(DELIMITER)
             .append(globalApprovalStatus).append(DELIMITER)
-            .append(Objects.nonNull(reportedPeriod) ? reportedPeriod : "").append(DELIMITER)
+            .append(reported ? reportingPeriod : "NotReported").append(DELIMITER)
             .append(totalPoints).append(DELIMITER)
             .append(publicationTypeChannelLevelPoints).append(DELIMITER)
             .append(creatorShareCount).append(DELIMITER)
@@ -159,7 +161,8 @@ public record TestNviCandidate(String identifier,
         private BigDecimal publicationTypeChannelLevelPoints;
         private int creatorShareCount;
         private BigDecimal internationalCollaborationFactor;
-        private String reportedPeriod;
+        private boolean reported;
+        private String reportingPeriod;
         private String globalApprovalStatus;
 
         private Builder() {
@@ -210,8 +213,13 @@ public record TestNviCandidate(String identifier,
             return this;
         }
 
-        public Builder withReportedPeriod(String reportedPeriod) {
-            this.reportedPeriod = reportedPeriod;
+        public Builder withReported(boolean reported) {
+            this.reported = reported;
+            return this;
+        }
+
+        public Builder withReportingPeriod(String reportingPeriod) {
+            this.reportingPeriod = reportingPeriod;
             return this;
         }
 
@@ -223,7 +231,8 @@ public record TestNviCandidate(String identifier,
         public TestNviCandidate build() {
             return new TestNviCandidate(identifier, isApplicable, modifiedDate, publicationDetails, approvals,
                                         totalPoints, publicationTypeChannelLevelPoints, creatorShareCount,
-                                        internationalCollaborationFactor, reportedPeriod, globalApprovalStatus);
+                                        internationalCollaborationFactor, reported, reportingPeriod,
+                                        globalApprovalStatus);
         }
     }
 }


### PR DESCRIPTION
- Following up [PR in NVI](https://github.com/BIBSYSDEV/nva-nvi/pull/268)
- Renamed `reportedPeriod` to `reported` and changed data type to boolean
- Added `ReportingPeriod` with property `year` in test data for candidate
- If candidate is not reported, return "NotReported" as value for `reportedYear` (see nvi sparql query)