### PR TITLE
SparqlEndpointQueryService

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ nva-commons-core = { group = 'com.github.bibsysdev', name = 'core', version.ref 
 nva-commons-apigateway = { group = 'com.github.bibsysdev', name = 'apigateway', version.ref = 'nva' }
 nva-eventhandlers = { group = 'com.github.bibsysdev', name = 'eventhandlers', version.ref = 'nva' }
 nva-identifiers = { group = 'com.github.bibsysdev', name = 'identifiers', version.ref = 'nva' }
+nva-commons-auth = { group = 'com.github.bibsysdev', name = 'auth', version.ref = 'nva' }
 
 jackson-core = { group = 'com.fasterxml.jackson.core', name = 'jackson-core', version.ref = 'jackson' }
 jackson-databind = { group = 'com.fasterxml.jackson.core', name = 'jackson-databind', version.ref = 'jackson' }

--- a/report-api/build.gradle
+++ b/report-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation(project(':data-report-commons'))
     implementation libs.nva.commons.core
     implementation libs.nva.commons.apigateway
+    implementation libs.nva.commons.auth
     implementation libs.nva.json
     implementation libs.bundles.jena
     implementation libs.jackson.databind

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
@@ -10,12 +10,14 @@ import com.google.common.net.MediaType;
 import commons.db.GraphStoreProtocolConnection;
 import commons.formatter.ResponseFormatter;
 import java.util.List;
+import java.util.Map;
 import no.sikt.nva.data.report.api.fetch.formatter.CsvFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
 import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
+import no.sikt.nva.data.report.api.fetch.service.SparqlQueryGenerator;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -23,6 +25,10 @@ import nva.commons.core.JacocoGenerated;
 
 public class FetchDataReport extends ApiGatewayHandler<Void, String> {
 
+    public static final String BEFORE_PLACEHOLDER = "__BEFORE__";
+    public static final String AFTER_PLACEHOLDER = "__AFTER__";
+    public static final String OFFSET_PLACEHOLDER = "__OFFSET__";
+    public static final String PAGE_SIZE_PLACEHOLDER = "__PAGE_SIZE__";
     private final DatabaseQueryService queryService;
 
     @JacocoGenerated
@@ -43,7 +49,9 @@ public class FetchDataReport extends ApiGatewayHandler<Void, String> {
     protected String processInput(Void input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
         var reportRequest = ReportRequest.fromRequestInfo(requestInfo);
         var reportFormat = reportRequest.getReportFormat();
-        var result = queryService.getResult(reportRequest, getFormatter(reportFormat));
+        var sparqlQuery = SparqlQueryGenerator.getSparqlQuery(reportRequest.getReportType().getType(),
+                                                              generateReplacementStrings(reportRequest));
+        var result = queryService.getResult(sparqlQuery, getFormatter(reportFormat));
         setIsBase64EncodedIfReportFormatExcel(reportFormat);
         return result;
     }
@@ -51,6 +59,15 @@ public class FetchDataReport extends ApiGatewayHandler<Void, String> {
     @Override
     protected Integer getSuccessStatusCode(Void input, String output) {
         return 200;
+    }
+
+    private static Map<String, String> generateReplacementStrings(ReportRequest reportRequest) {
+        return Map.of(
+            BEFORE_PLACEHOLDER, reportRequest.getBefore().toString(),
+            AFTER_PLACEHOLDER, reportRequest.getAfter().toString(),
+            OFFSET_PLACEHOLDER, String.valueOf(reportRequest.getOffset()),
+            PAGE_SIZE_PLACEHOLDER, String.valueOf(reportRequest.getPageSize())
+        );
     }
 
     private static ResponseFormatter getFormatter(ReportFormat reportFormat) {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
@@ -17,6 +17,7 @@ import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
 import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
+import no.sikt.nva.data.report.api.fetch.service.QueryService;
 import no.sikt.nva.data.report.api.fetch.service.SparqlQueryGenerator;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -29,7 +30,7 @@ public class FetchDataReport extends ApiGatewayHandler<Void, String> {
     public static final String AFTER_PLACEHOLDER = "__AFTER__";
     public static final String OFFSET_PLACEHOLDER = "__OFFSET__";
     public static final String PAGE_SIZE_PLACEHOLDER = "__PAGE_SIZE__";
-    private final DatabaseQueryService queryService;
+    private final QueryService queryService;
 
     @JacocoGenerated
     public FetchDataReport() {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchDataReport.java
@@ -15,7 +15,7 @@ import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
-import no.sikt.nva.data.report.api.fetch.service.QueryService;
+import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -23,14 +23,14 @@ import nva.commons.core.JacocoGenerated;
 
 public class FetchDataReport extends ApiGatewayHandler<Void, String> {
 
-    private final QueryService queryService;
+    private final DatabaseQueryService queryService;
 
     @JacocoGenerated
     public FetchDataReport() {
-        this(new QueryService(new GraphStoreProtocolConnection()));
+        this(new DatabaseQueryService(new GraphStoreProtocolConnection()));
     }
 
-    public FetchDataReport(QueryService queryService) {
+    public FetchDataReport(DatabaseQueryService queryService) {
         super(Void.class);
         this.queryService = queryService;
     }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -16,7 +16,7 @@ import no.sikt.nva.data.report.api.fetch.formatter.CsvFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
-import no.sikt.nva.data.report.api.fetch.service.QueryService;
+import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -33,14 +33,14 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
     private static final String ACCEPT = "Accept";
     private static final String NVI_INSTITUTION_SPARQL = "nvi-institution-status";
     private static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
-    private final QueryService queryService;
+    private final DatabaseQueryService queryService;
 
     @JacocoGenerated
     public FetchNviInstitutionReport() {
-        this(new QueryService(new GraphStoreProtocolConnection()));
+        this(new DatabaseQueryService(new GraphStoreProtocolConnection()));
     }
 
-    public FetchNviInstitutionReport(QueryService queryService) {
+    public FetchNviInstitutionReport(DatabaseQueryService queryService) {
         super(Void.class);
         this.queryService = queryService;
     }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -17,6 +17,7 @@ import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
+import no.sikt.nva.data.report.api.fetch.service.SparqlQueryGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -89,7 +90,8 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
     private String getResult(String reportingYear, String topLevelOrganization, ReportFormat reportFormat) {
         var replacementStrings = Map.of(REPLACE_REPORTING_YEAR, reportingYear,
                                         REPLACE_TOP_LEVEL_ORG, topLevelOrganization);
-        return queryService.getResult(NVI_INSTITUTION_SPARQL, replacementStrings, getFormatter(reportFormat));
+        var sparqlQuery = SparqlQueryGenerator.getSparqlQuery(NVI_INSTITUTION_SPARQL, replacementStrings);
+        return queryService.getResult(sparqlQuery, getFormatter(reportFormat));
     }
 
     private void validateAccessRights(RequestInfo requestInfo) throws UnauthorizedException {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -17,6 +17,7 @@ import no.sikt.nva.data.report.api.fetch.formatter.ExcelFormatter;
 import no.sikt.nva.data.report.api.fetch.formatter.PlainTextFormatter;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
+import no.sikt.nva.data.report.api.fetch.service.QueryService;
 import no.sikt.nva.data.report.api.fetch.service.SparqlQueryGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -34,7 +35,7 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
     private static final String ACCEPT = "Accept";
     private static final String NVI_INSTITUTION_SPARQL = "nvi-institution-status";
     private static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
-    private final DatabaseQueryService queryService;
+    private final QueryService queryService;
 
     @JacocoGenerated
     public FetchNviInstitutionReport() {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/DatabaseQueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/DatabaseQueryService.java
@@ -1,0 +1,68 @@
+package no.sikt.nva.data.report.api.fetch.service;
+
+import commons.db.DatabaseConnection;
+import commons.formatter.ResponseFormatter;
+import java.nio.file.Path;
+import java.util.Map;
+import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
+import nva.commons.core.ioutils.IoUtils;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+
+public class DatabaseQueryService implements QueryService {
+
+    public static final String TEMPLATE_DIRECTORY = "template";
+    public static final String SPARQL = ".sparql";
+    public static final String BEFORE_PLACEHOLDER = "__BEFORE__";
+    public static final String AFTER_PLACEHOLDER = "__AFTER__";
+    public static final String OFFSET_PLACEHOLDER = "__OFFSET__";
+    public static final String PAGE_SIZE_PLACEHOLDER = "__PAGE_SIZE__";
+    private final DatabaseConnection databaseConnection;
+
+    public DatabaseQueryService(DatabaseConnection databaseConnection) {
+        this.databaseConnection = databaseConnection;
+    }
+
+    public String getResult(ReportRequest reportRequest, ResponseFormatter formatter) {
+        var query = getQuery(reportRequest);
+        return databaseConnection.getResult(query, formatter);
+    }
+
+    @Override
+    public String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
+                            ResponseFormatter formatter) {
+        var query = getQuery(sparqlTemplate, replacementStrings);
+        return databaseConnection.getResult(query, formatter);
+    }
+
+    private static Path constructPath(String sparqlTemplate) {
+        return Path.of(TEMPLATE_DIRECTORY, sparqlTemplate + SPARQL);
+    }
+
+    private static String replaceStrings(String sparqlString, Map<String, String> replacementStrings) {
+        var resultString = sparqlString;
+        for (var entry : replacementStrings.entrySet()) {
+            resultString = resultString.replace(entry.getKey(), entry.getValue());
+        }
+        return resultString;
+    }
+
+    private Query getQuery(String sparqlTemplate, Map<String, String> replacementStrings) {
+        var template = constructPath(sparqlTemplate);
+        var sparqlString = replaceStrings(IoUtils.stringFromResources(template), replacementStrings);
+        return QueryFactory.create(sparqlString);
+    }
+
+    private Query getQuery(ReportRequest reportRequest) {
+        return QueryFactory.create(generateQuery(reportRequest));
+    }
+
+    private String generateQuery(ReportRequest reportRequest) {
+        var template = constructPath(reportRequest.getReportType().getType());
+        var sparqlTemplate = IoUtils.stringFromResources(template);
+        return sparqlTemplate.replace(BEFORE_PLACEHOLDER, reportRequest.getBefore().toString())
+                   .replace(AFTER_PLACEHOLDER, reportRequest.getAfter().toString())
+                   .replace(OFFSET_PLACEHOLDER, String.valueOf(reportRequest.getOffset()))
+                   .replace(PAGE_SIZE_PLACEHOLDER, String.valueOf(reportRequest.getPageSize()));
+    }
+}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/DatabaseQueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/DatabaseQueryService.java
@@ -2,67 +2,19 @@ package no.sikt.nva.data.report.api.fetch.service;
 
 import commons.db.DatabaseConnection;
 import commons.formatter.ResponseFormatter;
-import java.nio.file.Path;
-import java.util.Map;
-import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
-import nva.commons.core.ioutils.IoUtils;
-import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 
 public class DatabaseQueryService implements QueryService {
 
-    public static final String TEMPLATE_DIRECTORY = "template";
-    public static final String SPARQL = ".sparql";
-    public static final String BEFORE_PLACEHOLDER = "__BEFORE__";
-    public static final String AFTER_PLACEHOLDER = "__AFTER__";
-    public static final String OFFSET_PLACEHOLDER = "__OFFSET__";
-    public static final String PAGE_SIZE_PLACEHOLDER = "__PAGE_SIZE__";
     private final DatabaseConnection databaseConnection;
 
     public DatabaseQueryService(DatabaseConnection databaseConnection) {
         this.databaseConnection = databaseConnection;
     }
 
-    public String getResult(ReportRequest reportRequest, ResponseFormatter formatter) {
-        var query = getQuery(reportRequest);
-        return databaseConnection.getResult(query, formatter);
-    }
-
     @Override
-    public String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
-                            ResponseFormatter formatter) {
-        var query = getQuery(sparqlTemplate, replacementStrings);
+    public String getResult(String sparqlQuery, ResponseFormatter formatter) {
+        var query = QueryFactory.create(sparqlQuery);
         return databaseConnection.getResult(query, formatter);
-    }
-
-    private static Path constructPath(String sparqlTemplate) {
-        return Path.of(TEMPLATE_DIRECTORY, sparqlTemplate + SPARQL);
-    }
-
-    private static String replaceStrings(String sparqlString, Map<String, String> replacementStrings) {
-        var resultString = sparqlString;
-        for (var entry : replacementStrings.entrySet()) {
-            resultString = resultString.replace(entry.getKey(), entry.getValue());
-        }
-        return resultString;
-    }
-
-    private Query getQuery(String sparqlTemplate, Map<String, String> replacementStrings) {
-        var template = constructPath(sparqlTemplate);
-        var sparqlString = replaceStrings(IoUtils.stringFromResources(template), replacementStrings);
-        return QueryFactory.create(sparqlString);
-    }
-
-    private Query getQuery(ReportRequest reportRequest) {
-        return QueryFactory.create(generateQuery(reportRequest));
-    }
-
-    private String generateQuery(ReportRequest reportRequest) {
-        var template = constructPath(reportRequest.getReportType().getType());
-        var sparqlTemplate = IoUtils.stringFromResources(template);
-        return sparqlTemplate.replace(BEFORE_PLACEHOLDER, reportRequest.getBefore().toString())
-                   .replace(AFTER_PLACEHOLDER, reportRequest.getAfter().toString())
-                   .replace(OFFSET_PLACEHOLDER, String.valueOf(reportRequest.getOffset()))
-                   .replace(PAGE_SIZE_PLACEHOLDER, String.valueOf(reportRequest.getPageSize()));
     }
 }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/QueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/QueryService.java
@@ -1,9 +1,8 @@
 package no.sikt.nva.data.report.api.fetch.service;
 
 import commons.formatter.ResponseFormatter;
-import java.util.Map;
 
 public interface QueryService {
-    String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
-                     ResponseFormatter formatter);
+
+    String getResult(String sparqlQuery, ResponseFormatter formatter);
 }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/QueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/QueryService.java
@@ -1,67 +1,9 @@
 package no.sikt.nva.data.report.api.fetch.service;
 
-import commons.db.DatabaseConnection;
 import commons.formatter.ResponseFormatter;
-import java.nio.file.Path;
 import java.util.Map;
-import no.sikt.nva.data.report.api.fetch.model.ReportRequest;
-import nva.commons.core.ioutils.IoUtils;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryFactory;
 
-public class QueryService {
-
-    public static final String TEMPLATE_DIRECTORY = "template";
-    public static final String SPARQL = ".sparql";
-    public static final String BEFORE_PLACEHOLDER = "__BEFORE__";
-    public static final String AFTER_PLACEHOLDER = "__AFTER__";
-    public static final String OFFSET_PLACEHOLDER = "__OFFSET__";
-    public static final String PAGE_SIZE_PLACEHOLDER = "__PAGE_SIZE__";
-    private final DatabaseConnection databaseConnection;
-
-    public QueryService(DatabaseConnection databaseConnection) {
-        this.databaseConnection = databaseConnection;
-    }
-
-    public String getResult(ReportRequest reportRequest, ResponseFormatter formatter) {
-        var query = getQuery(reportRequest);
-        return databaseConnection.getResult(query, formatter);
-    }
-
-    public String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
-                            ResponseFormatter formatter) {
-        var query = getQuery(sparqlTemplate, replacementStrings);
-        return databaseConnection.getResult(query, formatter);
-    }
-
-    private static Path constructPath(String sparqlTemplate) {
-        return Path.of(TEMPLATE_DIRECTORY, sparqlTemplate + SPARQL);
-    }
-
-    private static String replaceStrings(String sparqlString, Map<String, String> replacementStrings) {
-        var resultString = sparqlString;
-        for (var entry : replacementStrings.entrySet()) {
-            resultString = resultString.replace(entry.getKey(), entry.getValue());
-        }
-        return resultString;
-    }
-
-    private Query getQuery(String sparqlTemplate, Map<String, String> replacementStrings) {
-        var template = constructPath(sparqlTemplate);
-        var sparqlString = replaceStrings(IoUtils.stringFromResources(template), replacementStrings);
-        return QueryFactory.create(sparqlString);
-    }
-
-    private Query getQuery(ReportRequest reportRequest) {
-        return QueryFactory.create(generateQuery(reportRequest));
-    }
-
-    private String generateQuery(ReportRequest reportRequest) {
-        var template = constructPath(reportRequest.getReportType().getType());
-        var sparqlTemplate = IoUtils.stringFromResources(template);
-        return sparqlTemplate.replace(BEFORE_PLACEHOLDER, reportRequest.getBefore().toString())
-                   .replace(AFTER_PLACEHOLDER, reportRequest.getAfter().toString())
-                   .replace(OFFSET_PLACEHOLDER, String.valueOf(reportRequest.getOffset()))
-                   .replace(PAGE_SIZE_PLACEHOLDER, String.valueOf(reportRequest.getPageSize()));
-    }
+public interface QueryService {
+    String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
+                     ResponseFormatter formatter);
 }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlEndpointQueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlEndpointQueryService.java
@@ -2,7 +2,6 @@ package no.sikt.nva.data.report.api.fetch.service;
 
 import commons.formatter.ResponseFormatter;
 import java.net.http.HttpClient;
-import java.util.Map;
 import no.unit.nva.auth.AuthorizedBackendClient;
 import no.unit.nva.auth.CognitoCredentials;
 import nva.commons.core.JacocoGenerated;
@@ -21,8 +20,7 @@ public class SparqlEndpointQueryService implements QueryService {
     }
 
     @Override
-    public String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
-                            ResponseFormatter formatter) {
+    public String getResult(String sparqlQuery, ResponseFormatter formatter) {
         var authorizedBackendClient = AuthorizedBackendClient.prepareWithCognitoCredentials(httpClient,
                                                                                             cognitoCredentials);
         return null;

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlEndpointQueryService.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlEndpointQueryService.java
@@ -1,0 +1,30 @@
+package no.sikt.nva.data.report.api.fetch.service;
+
+import commons.formatter.ResponseFormatter;
+import java.net.http.HttpClient;
+import java.util.Map;
+import no.unit.nva.auth.AuthorizedBackendClient;
+import no.unit.nva.auth.CognitoCredentials;
+import nva.commons.core.JacocoGenerated;
+
+//TODO: Use in FetchNviInstitutionReport handler
+//TODO: Implement
+@JacocoGenerated
+public class SparqlEndpointQueryService implements QueryService {
+
+    private final HttpClient httpClient;
+    private final CognitoCredentials cognitoCredentials;
+
+    public SparqlEndpointQueryService(HttpClient httpClient, CognitoCredentials cognitoCredentials) {
+        this.httpClient = httpClient;
+        this.cognitoCredentials = cognitoCredentials;
+    }
+
+    @Override
+    public String getResult(String sparqlTemplate, Map<String, String> replacementStrings,
+                            ResponseFormatter formatter) {
+        var authorizedBackendClient = AuthorizedBackendClient.prepareWithCognitoCredentials(httpClient,
+                                                                                            cognitoCredentials);
+        return null;
+    }
+}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlQueryGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlQueryGenerator.java
@@ -4,10 +4,14 @@ import java.nio.file.Path;
 import java.util.Map;
 import nva.commons.core.ioutils.IoUtils;
 
-public class SparqlQueryGenerator {
+public final class SparqlQueryGenerator {
 
     private static final String TEMPLATE_DIRECTORY = "template";
     private static final String SPARQL = ".sparql";
+
+    private SparqlQueryGenerator() {
+        //NO-OP
+    }
 
     public static String getSparqlQuery(String sparqlTemplate, Map<String, String> replacementStrings) {
         var template = constructPath(sparqlTemplate);

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlQueryGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/service/SparqlQueryGenerator.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.data.report.api.fetch.service;
+
+import java.nio.file.Path;
+import java.util.Map;
+import nva.commons.core.ioutils.IoUtils;
+
+public class SparqlQueryGenerator {
+
+    private static final String TEMPLATE_DIRECTORY = "template";
+    private static final String SPARQL = ".sparql";
+
+    public static String getSparqlQuery(String sparqlTemplate, Map<String, String> replacementStrings) {
+        var template = constructPath(sparqlTemplate);
+        return replaceStrings(IoUtils.stringFromResources(template), replacementStrings);
+    }
+
+    private static Path constructPath(String sparqlTemplate) {
+        return Path.of(TEMPLATE_DIRECTORY, sparqlTemplate + SPARQL);
+    }
+
+    private static String replaceStrings(String sparqlString, Map<String, String> replacementStrings) {
+        var resultString = sparqlString;
+        for (var entry : replacementStrings.entrySet()) {
+            resultString = resultString.replace(entry.getKey(), entry.getValue());
+        }
+        return resultString;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.util.Base64;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
 import no.sikt.nva.data.report.api.fetch.model.ReportType;
-import no.sikt.nva.data.report.api.fetch.service.QueryService;
+import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
 import no.sikt.nva.data.report.api.fetch.testutils.BadRequestProvider;
 import no.sikt.nva.data.report.api.fetch.testutils.ValidExcelRequestSource;
 import no.sikt.nva.data.report.api.fetch.testutils.ValidRequestSource;
@@ -51,7 +51,7 @@ class FetchDataReportTest extends LocalFusekiTest {
     @ArgumentsSource(BadRequestProvider.class)
     void shouldThrowBadRequest(FetchDataReportRequest report)
         throws IOException {
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var output = executeRequest(handler, generateHandlerRequest(report));
         var response = fromOutputStream(output, String.class);
@@ -63,7 +63,7 @@ class FetchDataReportTest extends LocalFusekiTest {
     void shouldReturnFormattedResult(FetchDataReportRequest request) throws IOException, BadRequestException {
         var testData = new TestData(generateDatePairs(2));
         loadModels(testData.getModels());
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var input = generateHandlerRequest(request);
         var output = executeRequest(handler, input);
@@ -81,7 +81,7 @@ class FetchDataReportTest extends LocalFusekiTest {
         throws IOException {
         var testData = new TestData(generateDatePairs(2));
         loadModels(testData.getModels());
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var input = generateHandlerRequest(request);
         var output = executeRequest(handler, input);
@@ -96,7 +96,7 @@ class FetchDataReportTest extends LocalFusekiTest {
         throws IOException, BadRequestException {
         var testData = new TestData(generateDatePairs(2));
         loadModels(testData.getModels());
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var input = generateHandlerRequest(request);
         var output = executeRequest(handler, input);
@@ -111,7 +111,7 @@ class FetchDataReportTest extends LocalFusekiTest {
     void shouldReturnResultWithOffset(ReportType reportType) throws IOException {
         var testData = new TestData(generateDatePairs(2));
         loadModels(testData.getModels());
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var pageSize = 1;
         var firstRequest = generateHandlerRequest(buildRequest(OFFSET_ZERO, valueOf(pageSize), reportType.getType()));
@@ -129,7 +129,7 @@ class FetchDataReportTest extends LocalFusekiTest {
     void shouldRetrieveManyHits() throws IOException, BadRequestException {
         var testData = new TestData(generateDatePairs(20));
         loadModels(testData.getModels());
-        var service = new QueryService(databaseConnection);
+        var service = new DatabaseQueryService(databaseConnection);
         var handler = new FetchDataReport(service);
         var request = new FetchDataReportRequest(
             TEXT_CSV.toString(),

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.util.Base64;
 import java.util.stream.Stream;
 import no.sikt.nva.data.report.api.fetch.model.ReportFormat;
-import no.sikt.nva.data.report.api.fetch.service.QueryService;
+import no.sikt.nva.data.report.api.fetch.service.DatabaseQueryService;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.TestData;
 import no.sikt.nva.data.report.api.fetch.testutils.requests.FetchNviInstitutionReportRequest;
@@ -51,7 +51,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     @BeforeEach
     void setUp() {
-        handler = new FetchNviInstitutionReport(new QueryService(databaseConnection));
+        handler = new FetchNviInstitutionReport(new DatabaseQueryService(databaseConnection));
     }
 
     @Test


### PR DESCRIPTION
- Rename `QueryService` to `DatabaseQueryService`.
- Add interface `QueryService`.
- Add `SparqlEndpointQueryService` -> to be used in next PR
- Move sparql template logic to new class `SparqlQueryGenerator`