### PR TITLE
Np 46410 FetchNviInstitutionReportHandler - change path

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -128,7 +128,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-  /nvi/institution:
+  //institution/nvi-approval:
     get:
       description: Get institution report for nvi for current year. Supporting text/csv download according to <https://www.rfc-editor.org/rfc/rfc4180>, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet and application/ld+json.
       security:
@@ -148,6 +148,12 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: reportingYear
+          description: The reporting year for which the report is requested
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: "OK"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -128,7 +128,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-  //institution/nvi-approval:
+  /institution/nvi-approval:
     get:
       description: Get institution report for nvi for current year. Supporting text/csv download according to <https://www.rfc-editor.org/rfc/rfc4180>, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet and application/ld+json.
       security:

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReport.java
@@ -27,13 +27,13 @@ import org.slf4j.LoggerFactory;
 
 public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
 
-    public static final String REPLACE_REPORTING_YEAR = "__REPLACE_WITH_REPORTING_YEAR__";
-    public static final String REPLACE_TOP_LEVEL_ORG = "__REPLACE_WITH_TOP_LEVEL_ORGANIZATION__";
-    public static final String QUERY_PARAM_INSTITUTION_ID = "institutionId";
     private static final Logger logger = LoggerFactory.getLogger(FetchNviInstitutionReport.class);
     private static final String ACCEPT = "Accept";
+    private static final String QUERY_PARAM_INSTITUTION_ID = "institutionId";
+    private static final String QUERY_PARAM_REPORTING_YEAR = "reportingYear";
     private static final String NVI_INSTITUTION_SPARQL = "nvi-institution-status";
-    private static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
+    private static final String REPLACE_REPORTING_YEAR = "__REPLACE_WITH_REPORTING_YEAR__";
+    private static final String REPLACE_TOP_LEVEL_ORG = "__REPLACE_WITH_TOP_LEVEL_ORGANIZATION__";
     private final QueryService queryService;
 
     @JacocoGenerated
@@ -53,7 +53,7 @@ public class FetchNviInstitutionReport extends ApiGatewayHandler<Void, String> {
 
     @Override
     protected String processInput(Void unused, RequestInfo requestInfo, Context context) throws BadRequestException {
-        var reportingYear = requestInfo.getPathParameter(PATH_PARAMETER_REPORTING_YEAR);
+        var reportingYear = requestInfo.getQueryParameter(QUERY_PARAM_REPORTING_YEAR);
         var topLevelOrganization =
             URLDecoder.decode(requestInfo.getQueryParameter(QUERY_PARAM_INSTITUTION_ID), UTF_8);
         logRequest(topLevelOrganization, reportingYear);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -47,6 +47,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     public static final String HARDCODED_INSTITUTION_ID = organizationUri(SOME_TOP_LEVEL_IDENTIFIER);
     public static final String QUERY_PARAM_INSTITUTION_ID = "institutionId";
     public static final String QUERY_PARAM_REPORTING_YEAR = "reportingYear";
+    public static final String TEXT_PLAIN = "text/plain";
     private FetchNviInstitutionReport handler;
 
     @BeforeEach
@@ -56,7 +57,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
 
     @Test
     void shouldReturnBadRequestIfQueryParameterInstitutionIdIsMissing() throws IOException {
-        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(SOME_YEAR, null, "text/plain"));
+        var request = generateHandlerRequest(new FetchNviInstitutionReportRequest(SOME_YEAR, null, TEXT_PLAIN));
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);
@@ -69,7 +70,7 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     @Test
     void shouldReturnBadRequestIfQueryParameterReportingYearIsMissing() throws IOException {
         var request = generateHandlerRequest(
-            new FetchNviInstitutionReportRequest(null, randomUri().toString(), "text/plain"));
+            new FetchNviInstitutionReportRequest(null, randomUri().toString(), TEXT_PLAIN));
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);
@@ -80,26 +81,15 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     }
 
     @Test
-    void shouldExtractAndLogPathParameterReportingYear() throws IOException {
+    void shouldExtractAndLogQueryParameters() throws IOException {
         var logAppender = LogUtils.getTestingAppenderForRootLogger();
         var request = generateHandlerRequest(
-            new FetchNviInstitutionReportRequest(SOME_YEAR, randomUri().toString(), "text/plain"));
+            new FetchNviInstitutionReportRequest(SOME_YEAR, HARDCODED_INSTITUTION_ID, TEXT_PLAIN));
         var output = new ByteArrayOutputStream();
         var context = new FakeContext();
         handler.handleRequest(request, output, context);
+        assertTrue(logAppender.getMessages().contains("for organization: " + HARDCODED_INSTITUTION_ID));
         assertTrue(logAppender.getMessages().contains("reporting year: " + SOME_YEAR));
-    }
-
-    @Test
-    void shouldLogQueryParamInstitutionId() throws IOException {
-        var logAppender = LogUtils.getTestingAppenderForRootLogger();
-        var topLevelCristinOrgId = randomUri();
-        var request = generateHandlerRequest(
-            new FetchNviInstitutionReportRequest(SOME_YEAR, topLevelCristinOrgId.toString(), "text/plain"));
-        var output = new ByteArrayOutputStream();
-        var context = new FakeContext();
-        handler.handleRequest(request, output, context);
-        assertTrue(logAppender.getMessages().contains("for organization: " + topLevelCristinOrgId));
     }
 
     @ParameterizedTest
@@ -157,13 +147,9 @@ public class FetchNviInstitutionReportTest extends LocalFusekiTest {
     }
 
     private static Stream<Arguments> fetchNviInstitutionReportRequestProvider() {
-        return Stream.of(Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, HARDCODED_INSTITUTION_ID, "text"
-                                                                                                                +
-                                                                                                                "/plain")),
-                         Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, HARDCODED_INSTITUTION_ID, "text"
-                                                                                                                +
-                                                                                                                "/csv"
-                         )));
+        return Stream.of(
+            Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, HARDCODED_INSTITUTION_ID, TEXT_PLAIN)),
+            Arguments.of(new FetchNviInstitutionReportRequest(SOME_YEAR, HARDCODED_INSTITUTION_ID, "text/csv")));
     }
 
     private static Stream<Arguments> fetchNviInstitutionReportExcelRequestProvider() {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
@@ -9,12 +9,13 @@ public record FetchNviInstitutionReportRequest(String reportingYear,
                                                String institutionId,
                                                String accept) {
 
-    public Map<String, String> pathParameters() {
-        return Map.of("reportingYear", reportingYear);
+    public Map<String, String> queryParameters() {
+        return Map.of("institutionId", URLEncoder.encode(getInstitutionId(), UTF_8),
+                      "reportingYear", getReportingYear());
     }
 
-    public Map<String, String> queryParameters() {
-        return Map.of("institutionId", URLEncoder.encode(getInstitutionId(), UTF_8));
+    private String getReportingYear() {
+        return isNull(reportingYear) ? "" : reportingYear;
     }
 
     public Map<String, String> acceptHeader() {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/requests/FetchNviInstitutionReportRequest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.data.report.api.fetch.testutils.requests;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
+import static nva.commons.apigateway.RestRequestHandler.EMPTY_STRING;
 import java.net.URLEncoder;
 import java.util.Map;
 
@@ -14,15 +15,15 @@ public record FetchNviInstitutionReportRequest(String reportingYear,
                       "reportingYear", getReportingYear());
     }
 
-    private String getReportingYear() {
-        return isNull(reportingYear) ? "" : reportingYear;
-    }
-
     public Map<String, String> acceptHeader() {
         return Map.of("Accept", accept);
     }
 
+    private String getReportingYear() {
+        return isNull(reportingYear) ? EMPTY_STRING : reportingYear;
+    }
+
     private String getInstitutionId() {
-        return isNull(institutionId) ? "" : institutionId;
+        return isNull(institutionId) ? EMPTY_STRING : institutionId;
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -341,7 +341,7 @@ Resources:
         ApiEvent:
           Type: Api
           Properties:
-            Path: /nvi/institution
+            Path: /institution/nvi-approval
             Method: get
             RestApiId: !Ref DataReportApi
 


### PR DESCRIPTION
For `FetchNviInstitutionReportHandler`:
- Change path to: `/report/institution/nvi-approval`
- Make `reportingYear` required query param