### PR TITLE
Np 46410 Handle errors in NviInstitutionReportClient

### DIFF
--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
@@ -4,7 +4,6 @@ import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
 import static com.google.common.net.MediaType.OOXML_SHEET;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_CSV;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_PLAIN;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.MediaType;
 import java.net.URI;
@@ -61,7 +60,7 @@ public class FetchNviInstitutionReportProxy extends ApiGatewayHandler<Void, Stri
         var acceptHeader = requestInfo.getHeader(ACCEPT_HEADER);
         setIsBase64EncodedIfContentTypeIsExcel(acceptHeader);
         logRequest(topLevelOrganization, reportingYear);
-        return attempt(() -> reportClient.fetchReport(reportingYear, topLevelOrganization, acceptHeader)).orElseThrow();
+        return reportClient.fetchReport(reportingYear, topLevelOrganization, acceptHeader);
     }
 
     @Override

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
@@ -58,7 +58,7 @@ public class NviInstitutionReportClient {
     private String executeRequest(Builder request)
         throws IOException, InterruptedException, ApiGatewayException {
         var response = authorizedBackendClient.send(request, BodyHandlers.ofString(UTF_8));
-        if (!(HTTP_OK == response.statusCode())) {
+        if (HTTP_OK != response.statusCode()) {
             handleError(response);
         }
         return response.body();

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
@@ -1,17 +1,29 @@
 package no.sikt.nva.data.report.api.fetch.client;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static nva.commons.core.attempt.Try.attempt;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import no.unit.nva.auth.AuthorizedBackendClient;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.paths.UriWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NviInstitutionReportClient {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NviInstitutionReportClient.class);
     private static final String ACCEPT_HEADER = "Accept";
     private static final String CUSTOM_DOMAIN_PATH = "report";
     private static final String INSTITUTION_PATH = "institution";
@@ -27,10 +39,40 @@ public class NviInstitutionReportClient {
     }
 
     public String fetchReport(String reportingYear, String topLevelOrganization, String acceptHeader)
-        throws IOException, InterruptedException {
+        throws ApiGatewayException {
         var request = generateRequest(reportingYear, topLevelOrganization, acceptHeader);
+        return attempt(() -> executeRequest(request)).orElseThrow(
+            failure -> logAndCreateBadGatewayException(request.build().uri(), failure.getException()));
+    }
+
+    private ApiGatewayException logAndCreateBadGatewayException(URI uri, Exception e) {
+        LOGGER.error("Unable to reach upstream: {}", uri, e);
+        if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        } else if (e instanceof ApiGatewayException) {
+            return (ApiGatewayException) e;
+        }
+        return new BadGatewayException("Unable to reach upstream!");
+    }
+
+    private String executeRequest(Builder request)
+        throws IOException, InterruptedException, ApiGatewayException {
         var response = authorizedBackendClient.send(request, BodyHandlers.ofString(UTF_8));
+        if (!(HTTP_OK == (response.statusCode()))) {
+            handleError(response);
+        }
         return response.body();
+    }
+
+    private void handleError(HttpResponse<String> response) throws ApiGatewayException {
+        if (HTTP_NOT_FOUND == response.statusCode()) {
+            throw new NotFoundException("Report not found!");
+        }
+        if (HTTP_BAD_REQUEST == response.statusCode()) {
+            throw new BadRequestException(response.body());
+        }
+        LOGGER.error("Error fetching report: {} {}", response.statusCode(), response.body());
+        throw new BadGatewayException("Unexpected response from upstream!");
     }
 
     private Builder generateRequest(String reportingYear, String topLevelOrganization, String acceptHeader) {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
@@ -49,8 +49,8 @@ public class NviInstitutionReportClient {
         LOGGER.error("Unable to reach upstream: {}", uri, e);
         if (e instanceof InterruptedException) {
             Thread.currentThread().interrupt();
-        } else if (e instanceof ApiGatewayException) {
-            return (ApiGatewayException) e;
+        } else if (e instanceof ApiGatewayException gatewayException) {
+            return gatewayException;
         }
         return new BadGatewayException("Unable to reach upstream!");
     }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/client/NviInstitutionReportClient.java
@@ -58,7 +58,7 @@ public class NviInstitutionReportClient {
     private String executeRequest(Builder request)
         throws IOException, InterruptedException, ApiGatewayException {
         var response = authorizedBackendClient.send(request, BodyHandlers.ofString(UTF_8));
-        if (!(HTTP_OK == (response.statusCode()))) {
+        if (!(HTTP_OK == response.statusCode())) {
             handleError(response);
         }
         return response.body();


### PR DESCRIPTION
- Handle `400`, `404` -> or else throw `BadGatewayException`