### PR TITLE
Make permissions explicit and precise

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -315,7 +315,7 @@ Resources:
       CodeUri: report-api
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReportProxy::handleRequest
       Policies:
-        - PolicyName: 'SecretsManagerPolicy'
+        - PolicyName: secretsManagerPolicy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -454,7 +454,7 @@ Resources:
       AutoPublishAlias: live
       Policies:
         - !GetAtt S3ManagedPolicy.PolicyArn
-        - PolicyName: 'DeleteS3Object'
+        - PolicyName: deleteS3Object
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/template.yaml
+++ b/template.yaml
@@ -317,13 +317,13 @@ Resources:
       Policies:
         - PolicyName: 'SecretsManagerPolicy'
           PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Action:
-                - secretsmanager:GetSecretValue
-              Resource:
-                - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:BackendCognitoClientCredentials-*"
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:BackendCognitoClientCredentials-*"
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -456,14 +456,14 @@ Resources:
         - !GetAtt S3ManagedPolicy.PolicyArn
         - PolicyName: 'DeleteS3Object'
           PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Action:
-                - 's3:DeleteObject'
-              Resource:
-                - !Ref KeyBatchesBucket
-                - !Sub '${KeyBatchesBucket.Arn}/*'
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:DeleteObject'
+                Resource:
+                  - !Ref KeyBatchesBucket
+                  - !Sub '${KeyBatchesBucket.Arn}/*'
       Environment:
         Variables:
           EVENT_BUS: !GetAtt BatchLoadEventBus.Name

--- a/template.yaml
+++ b/template.yaml
@@ -315,8 +315,9 @@ Resources:
       CodeUri: report-api
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReportProxy::handleRequest
       Policies:
-        - Version: '2012-10-17'
-          PolicyName: 'SecretsManagerPolicy'
+        - PolicyName: 'SecretsManagerPolicy'
+          PolicyDocument:
+          Version: '2012-10-17'
           Statement:
             - Effect: Allow
               Action:
@@ -453,8 +454,9 @@ Resources:
       AutoPublishAlias: live
       Policies:
         - !GetAtt S3ManagedPolicy.PolicyArn
-        - Version: '2012-10-17'
-          PolicyName: 'DeleteS3Object'
+        - PolicyName: 'DeleteS3Object'
+          PolicyDocument:
+          Version: '2012-10-17'
           Statement:
             - Effect: Allow
               Action:

--- a/template.yaml
+++ b/template.yaml
@@ -115,6 +115,31 @@ Resources:
 
   # ---- Policies ----
 
+  SecretsManagerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+            Resource:
+              - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:BackendCognitoClientCredentials-*"
+
+  DeleteS3ObjectPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:DeleteObject'
+            Resource:
+              - !Ref KeyBatchesBucket
+              - !Sub '${KeyBatchesBucket.Arn}/*'
+
   S3ManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -255,6 +280,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: report-api
+      Handler: no.sikt.nva.data.report.api.fetch.FetchDataReport::handleRequest
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup
@@ -264,7 +290,6 @@ Resources:
       Policies:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Handler: no.sikt.nva.data.report.api.fetch.FetchDataReport::handleRequest
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -282,6 +307,7 @@ Resources:
   FetchNviInstitutionReportHandler:
     Type: AWS::Serverless::Function
     Properties:
+      Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
       CodeUri: report-api
       VpcConfig:
         SecurityGroupIds:
@@ -292,7 +318,6 @@ Resources:
       Policies:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -313,15 +338,7 @@ Resources:
       CodeUri: report-api
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReportProxy::handleRequest
       Policies:
-        - PolicyName: secretsManagerPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - secretsmanager:GetSecretValue
-                Resource:
-                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:BackendCognitoClientCredentials-*"
+        - !GetAtt SecretsManagerPolicy.PolicyArn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -341,6 +358,7 @@ Resources:
   DataLoadingHandler:
     Type: AWS::Serverless::Function
     Properties:
+      Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
       CodeUri: data-loading
       VpcConfig:
         SecurityGroupIds:
@@ -353,7 +371,6 @@ Resources:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt SqsManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -372,6 +389,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: bulk-load
+      Handler: no.sikt.nva.data.report.api.etl.loader.BulkLoadHandler::handleRequest
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup
@@ -382,7 +400,6 @@ Resources:
         - !GetAtt S3ManagedPolicy.PolicyArn
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Handler: no.sikt.nva.data.report.api.etl.loader.BulkLoadHandler::handleRequest
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -398,6 +415,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: database-tools
+      Handler: no.sikt.nva.data.report.dbtools.DatabaseResetHandler::handleRequest
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup
@@ -407,7 +425,6 @@ Resources:
       Policies:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Handler: no.sikt.nva.data.report.dbtools.DatabaseResetHandler::handleRequest
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -449,16 +466,7 @@ Resources:
       AutoPublishAlias: live
       Policies:
         - !GetAtt S3ManagedPolicy.PolicyArn
-        - PolicyName: deleteS3Object
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - 's3:DeleteObject'
-                Resource:
-                  - !Ref KeyBatchesBucket
-                  - !Sub '${KeyBatchesBucket.Arn}/*'
+        - !GetAtt DeleteS3ObjectPolicy.PolicyArn
       Environment:
         Variables:
           EVENT_BUS: !GetAtt BatchLoadEventBus.Name

--- a/template.yaml
+++ b/template.yaml
@@ -262,7 +262,6 @@ Resources:
           - !Ref LambdaSubnet1
           - !Ref LambdaSubnet2
       Policies:
-        - VPCAccessPolicy: { }
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.fetch.FetchDataReport::handleRequest
@@ -291,7 +290,6 @@ Resources:
           - !Ref LambdaSubnet1
           - !Ref LambdaSubnet2
       Policies:
-        - VPCAccessPolicy: { }
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
@@ -351,7 +349,6 @@ Resources:
           - !Ref LambdaSubnet1
           - !Ref LambdaSubnet2
       Policies:
-        - VPCAccessPolicy: { }
         - !GetAtt S3ManagedPolicy.PolicyArn
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt SqsManagedPolicy.PolicyArn
@@ -382,7 +379,6 @@ Resources:
           - !Ref LambdaSubnet1
           - !Ref LambdaSubnet2
       Policies:
-        - VPCAccessPolicy: { }
         - !GetAtt S3ManagedPolicy.PolicyArn
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
@@ -409,7 +405,6 @@ Resources:
           - !Ref LambdaSubnet1
           - !Ref LambdaSubnet2
       Policies:
-        - VPCAccessPolicy: { }
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.dbtools.DatabaseResetHandler::handleRequest

--- a/template.yaml
+++ b/template.yaml
@@ -137,7 +137,7 @@ Resources:
             Action:
               - 's3:DeleteObject'
             Resource:
-              - !Ref KeyBatchesBucket.Arn
+              - !GetAtt KeyBatchesBucket.Arn
 
   S3ManagedPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -137,8 +137,7 @@ Resources:
             Action:
               - 's3:DeleteObject'
             Resource:
-              - !Ref KeyBatchesBucket
-              - !Sub '${KeyBatchesBucket.Arn}/*'
+              - !Ref KeyBatchesBucket.Arn
 
   S3ManagedPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -112,98 +112,62 @@ Resources:
     Properties:
       LogGroupName: !Sub '/aws/lambda/${DataLoadingHandler}'
       RetentionInDays: 5
-  # ---- Lambda ----
 
-  LambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ lambda.amazonaws.com ]
-            Action: [ 'sts:AssumeRole' ]
-      Policies:
-        - PolicyName: readFromS3
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:Get*
-                  - s3:List*
-                  - s3:PutObject
-                  - events:*
-                Resource: '*'
-        - PolicyName: neptuneAccessPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - neptune-db:*
-                Resource:
-                  - !Sub 'arn:aws:neptune-db:${AWS::Region}:${AWS::AccountId}:cluster:${ProjectName}/*'
-        - PolicyName: queuePolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - sqs:ReceiveMessage
-                  - sqs:DeleteMessage
-                  - sqs:SendMessage
-                  - sqs:GetQueueAttributes
-                Resource:
-                  - !GetAtt DataLoadingDLQ.Arn
-        - PolicyName: writeLog
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
-        - PolicyName: invokeFunction
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - lambda:InvokeFunction
-                Resource: '*'
-        - PolicyName: deployToVpnPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:DescribeNetworkInterfaces
-                  - ec2:CreateNetworkInterface
-                  - ec2:DeleteNetworkInterface
-                  - ec2:DescribeInstances
-                  - ec2:AttachNetworkInterface
-                Resource: '*'
+  # ---- Policies ----
 
-  DefaultLambdaPermissions:
-    Type: AWS::IAM::Policy
+  S3ManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: !Sub DefaultLambdaPermissions-${AWS::StackName}
-      Roles:
-        - !Ref LambdaRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              - lambda:InvokeFunction
-            Resource: "*"
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+              - events:*
+            Resource: '*'
+
+  NeptuneManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - neptune-db:*
+            Resource:
+              - !Sub 'arn:aws:neptune-db:${AWS::Region}:${AWS::AccountId}:cluster:${ProjectName}/*'
+  SqsManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+              - sqs:SendMessage
+              - sqs:GetQueueAttributes
+            Resource:
+              - !GetAtt DataLoadingDLQ.Arn
+  DeployToVpnPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeNetworkInterfaces
+              - ec2:CreateNetworkInterface
+              - ec2:DeleteNetworkInterface
+              - ec2:DescribeInstances
+              - ec2:AttachNetworkInterface
+            Resource: '*'
 
   InvokeLambdaPermission:
     Type: AWS::Lambda::Permission
@@ -299,8 +263,9 @@ Resources:
           - !Ref LambdaSubnet2
       Policies:
         - VPCAccessPolicy: { }
+        - !GetAtt NeptuneManagedPolicy.PolicyArn
+        - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.fetch.FetchDataReport::handleRequest
-      Role: !GetAtt LambdaRole.Arn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -327,6 +292,8 @@ Resources:
           - !Ref LambdaSubnet2
       Policies:
         - VPCAccessPolicy: { }
+        - !GetAtt NeptuneManagedPolicy.PolicyArn
+        - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
       Role: !GetAtt LambdaRole.Arn
       Timeout: 600
@@ -335,7 +302,6 @@ Resources:
       Environment:
         Variables:
           ALLOWED_ORIGIN: '*'
-          COGNITO_HOST: !Ref CognitoAuthorizationUri
       Events:
         ApiEvent:
           Type: Api
@@ -349,7 +315,15 @@ Resources:
     Properties:
       CodeUri: report-api
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReportProxy::handleRequest
-      Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - Version: '2012-10-17'
+          PolicyName: 'SecretsManagerPolicy'
+          Statement:
+            - Effect: Allow
+              Action:
+                - secretsmanager:GetSecretValue
+              Resource:
+                - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:BackendCognitoClientCredentials-*"
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -378,6 +352,10 @@ Resources:
           - !Ref LambdaSubnet2
       Policies:
         - VPCAccessPolicy: { }
+        - !GetAtt S3ManagedPolicy.PolicyArn
+        - !GetAtt NeptuneManagedPolicy.PolicyArn
+        - !GetAtt SqsManagedPolicy.PolicyArn
+        - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
       Role: !GetAtt LambdaRole.Arn
       Timeout: 600
@@ -394,7 +372,6 @@ Resources:
             Type: SQS
             Destination: !GetAtt DataLoadingDLQ.Arn
 
-
   BulkDataLoader:
     Type: AWS::Serverless::Function
     Properties:
@@ -407,6 +384,9 @@ Resources:
           - !Ref LambdaSubnet2
       Policies:
         - VPCAccessPolicy: { }
+        - !GetAtt S3ManagedPolicy.PolicyArn
+        - !GetAtt NeptuneManagedPolicy.PolicyArn
+        - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.etl.loader.BulkLoadHandler::handleRequest
       Timeout: 600
       MemorySize: 1536
@@ -431,6 +411,8 @@ Resources:
           - !Ref LambdaSubnet2
       Policies:
         - VPCAccessPolicy: { }
+        - !GetAtt NeptuneManagedPolicy.PolicyArn
+        - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.dbtools.DatabaseResetHandler::handleRequest
       Role: !GetAtt LambdaRole.Arn
       Timeout: 600
@@ -444,7 +426,8 @@ Resources:
     Properties:
       CodeUri: bulk-load
       Handler: no.sikt.nva.data.report.api.etl.transformer.GenerateKeyBatchesHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !GetAtt S3ManagedPolicy.PolicyArn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -468,12 +451,13 @@ Resources:
     Properties:
       CodeUri: bulk-load
       Handler: no.sikt.nva.data.report.api.etl.transformer.BulkTransformerHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
       Policies:
+        - !GetAtt S3ManagedPolicy.PolicyArn
         - Version: '2012-10-17'
+          PolicyName: 'DeleteS3Object'
           Statement:
             - Effect: Allow
               Action:

--- a/template.yaml
+++ b/template.yaml
@@ -295,7 +295,6 @@ Resources:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.fetch.FetchNviInstitutionReport::handleRequest
-      Role: !GetAtt LambdaRole.Arn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -357,7 +356,6 @@ Resources:
         - !GetAtt SqsManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
-      Role: !GetAtt LambdaRole.Arn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live
@@ -414,7 +412,6 @@ Resources:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
       Handler: no.sikt.nva.data.report.dbtools.DatabaseResetHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
       Timeout: 600
       MemorySize: 1536
       AutoPublishAlias: live


### PR DESCRIPTION
Inspired by @torbjokv's sharings:
- Make managed policies and define explicitly for lambdas. 
- Add policy `SecretsManagerPolicy` for `FetchNviInstitutionReportProxyHandler`