### PR TITLE
FetchNviInstitutionReportProxy: Fix secret name

### DIFF
--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
@@ -38,7 +38,7 @@ public class FetchNviInstitutionReportProxy extends ApiGatewayHandler<Void, Stri
     @JacocoGenerated
     public FetchNviInstitutionReportProxy() {
         this(new NviInstitutionReportClient(
-            AuthorizedBackendClient.prepareWithCognitoCredentials(readCognitoCredentials()),
+            AuthorizedBackendClient.prepareWithCognitoCredentials(readCognitoCredentials(new Environment())),
             new Environment().readEnv(API_HOST)));
     }
 
@@ -69,9 +69,10 @@ public class FetchNviInstitutionReportProxy extends ApiGatewayHandler<Void, Stri
     }
 
     @JacocoGenerated
-    private static CognitoCredentials readCognitoCredentials() {
+    private static CognitoCredentials readCognitoCredentials(Environment environment) {
         return Optional.of(
-                new SecretsReader().fetchClassSecret(BACKEND_CLIENT_SECRET_NAME, BackendClientCredentials.class))
+                new SecretsReader().fetchClassSecret(environment.readEnv(BACKEND_CLIENT_SECRET_NAME),
+                                                     BackendClientCredentials.class))
                    .map(FetchNviInstitutionReportProxy::mapToCognitoCredentials)
                    .orElseThrow();
     }


### PR DESCRIPTION
Fix: Use env var (not string) `BACKEND_CLIENT_SECRET_NAME` in `FetchNviInstitutionReportProxy`