### PR TITLE
Np 46455 Fix RAPPORTSTATUS

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -26,7 +26,7 @@ SELECT DISTINCT
   ?SIDEANTALL
   ?VA_TITTEL
   ?SPRAK
-  ?RAPPORTERT_STATUS
+  ?RAPPORTSTATUS
   ?VEKTINGSTALL
   ?FAKTORTALL_SAMARBEID
   ?FORFATTERDEL
@@ -37,7 +37,14 @@ SELECT DISTINCT
                :publicationDetails ?publicationUri ;
                :isApplicable ?isApplicable ;
                :internationalCollaborationFactor ?FAKTORTALL_SAMARBEID ;
+               :globalApprovalStatus ?globalApprovalStatus ;
                :publicationTypeChannelLevelPoints ?VEKTINGSTALL .
+
+       BIND(
+         IF(?globalApprovalStatus = "Pending", "?",
+         IF(?globalApprovalStatus = "Approved", "J",
+         IF(?globalApprovalStatus = "Rejected", "N", xsd:string(?a)))) AS ?RAPPORTSTATUS
+       )
 
        BIND(REPLACE(STR(?publicationUri), "^.*/([^/]*)$", "$1") AS ?VARBEIDLOPENR)
 
@@ -63,11 +70,6 @@ SELECT DISTINCT
        BIND(STRBEFORE(str(?identifier), ".") AS ?INSTITUSJONSNR)
        BIND(STRBEFORE(str(?temp1), ".") AS ?AVDNR)
        BIND(STRBEFORE(str(?temp2), ".") AS ?UNDAVDNR)
-
-       OPTIONAL {
-         ?candidate :reported ?reported .
-         BIND(IF(?reported = true, "Rapportert", "Ikke rapportert") AS ?RAPPORTERT_STATUS)
-       }
 
        #These are todos
        BIND("FORFATTERE_TOTALT" AS ?FORFATTERE_TOTALT)

--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -43,7 +43,7 @@ SELECT DISTINCT
        BIND(
          IF(?globalApprovalStatus = "Pending", "?",
          IF(?globalApprovalStatus = "Approved", "J",
-         IF(?globalApprovalStatus = "Rejected", "N", xsd:string(?a)))) AS ?RAPPORTSTATUS
+         IF(?globalApprovalStatus = "Rejected", "N", xsd:string(?globalApprovalStatus)))) AS ?RAPPORTSTATUS
        )
 
        BIND(REPLACE(STR(?publicationUri), "^.*/([^/]*)$", "$1") AS ?VARBEIDLOPENR)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
@@ -24,7 +24,7 @@ public final class NviInstitutionStatusHeaders {
     public static final String PAGE_COUNT = "SIDEANTALL";
     public static final String PUBLICATION_TITLE = "VA_TITTEL";
     public static final String LANGUAGE = "SPRAK";
-    public static final String IS_REPORTED = "RAPPORTERT_STATUS"; //TODO: Check if this is correct
+    public static final String GLOBAL_STATUS = "RAPPORTSTATUS";
     public static final String TOTAL_POINTS = "VEKTINGSTALL"; //TODO: Check if this is correct
     public static final String INTERNATIONAL_COLLABORATION_FACTOR = "FAKTORTALL_SAMARBEID";
     public static final String AUTHOR_SHARE_COUNT = "FORFATTERDEL";

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -12,7 +12,7 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstituti
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INSTITUTION_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INTERNATIONAL_COLLABORATION_FACTOR;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.ISSN;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.IS_REPORTED;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.GLOBAL_STATUS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LANGUAGE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LAST_NAME;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PAGE_COUNT;
@@ -31,6 +31,7 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.publication.
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
@@ -61,7 +62,7 @@ public final class NviInstitutionStatusTestData {
                                                                               PAGE_COUNT,
                                                                               PUBLICATION_TITLE,
                                                                               LANGUAGE,
-                                                                              IS_REPORTED,
+                                                                              GLOBAL_STATUS,
                                                                               TOTAL_POINTS,
                                                                               INTERNATIONAL_COLLABORATION_FACTOR,
                                                                               AUTHOR_SHARE_COUNT,
@@ -106,11 +107,19 @@ public final class NviInstitutionStatusTestData {
             .append(PAGE_COUNT).append(DELIMITER)//TODO: Implement
             .append(publication.getMainTitle()).append(DELIMITER)
             .append(LANGUAGE).append(DELIMITER)//TODO: Implement
-            .append(candidate.reported() ? "Rapportert" : "Ikke rapportert").append(DELIMITER)
+            .append(getExpectedGlobalStatus(candidate.globalApprovalStatus())).append(DELIMITER)
             .append(candidate.publicationTypeChannelLevelPoints()).append(DELIMITER) //TODO: Check if correct
             .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
             .append(POINTS_FOR_AFFILIATION).append(CRLF.getString());//TODO: Implement
+    }
+
+    private static String getExpectedGlobalStatus(TestApprovalStatus globalApprovalStatus) {
+        return switch (globalApprovalStatus) {
+            case APPROVED -> "J";
+            case REJECTED -> "N";
+            case PENDING -> "?";
+        };
     }
 
     private static TestApproval findExpectedApproval(TestNviOrganization affiliation, TestNviCandidate candidate) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.TestData.DatePair;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
-import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval.ApprovalStatus;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate.Builder;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
@@ -177,7 +177,7 @@ public final class NviTestData {
     private static TestApproval generateApproval(String topLevelOrganization) {
         return TestApproval.builder()
                    .withInstitutionId(URI.create(topLevelOrganization))
-                   .withApprovalStatus(randomElement(ApprovalStatus.values()))
+                   .withApprovalStatus(randomElement(TestApprovalStatus.values()))
                    .withPoints(randomBigDecimal())
                    .build();
     }
@@ -193,7 +193,7 @@ public final class NviTestData {
                    .withApprovals(approvals)
                    .withCreatorShareCount(countCombinationsOfCreatorsAndAffiliations(publicationDetails))
                    .withInternationalCollaborationFactor(BigDecimal.ONE)
-                   .withGlobalApprovalStatus(ApprovalStatus.PENDING.getValue())
+                   .withGlobalApprovalStatus(TestApprovalStatus.PENDING)
                    .withPublicationTypeChannelLevelPoints(randomBigDecimal())
                    .withTotalPoints(randomBigDecimal())
                    .withReportingPeriod(reportingPeriod);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
@@ -5,7 +5,7 @@ import java.net.URI;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 
 public record TestApproval(URI institutionId,
-                           ApprovalStatus approvalStatus,
+                           TestApprovalStatus approvalStatus,
                            BigDecimal points) {
 
     public static Builder builder() {
@@ -16,27 +16,10 @@ public record TestApproval(URI institutionId,
         return new ApprovalGenerator();
     }
 
-    public enum ApprovalStatus {
-
-        PENDING("Pending"),
-        APPROVED("Approved"),
-        REJECTED("Rejected");
-
-        private final String value;
-
-        ApprovalStatus(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-    }
-
     public static final class Builder {
 
         private URI institutionId;
-        private ApprovalStatus approvalStatus;
+        private TestApprovalStatus approvalStatus;
         private BigDecimal points;
 
         private Builder() {
@@ -47,7 +30,7 @@ public record TestApproval(URI institutionId,
             return this;
         }
 
-        public Builder withApprovalStatus(ApprovalStatus approvalStatus) {
+        public Builder withApprovalStatus(TestApprovalStatus approvalStatus) {
             this.approvalStatus = approvalStatus;
             return this;
         }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
@@ -14,14 +14,6 @@ public enum TestApprovalStatus {
         this.value = value;
     }
 
-    @JsonCreator
-    public static TestApprovalStatus parse(String value) {
-        return Arrays.stream(TestApprovalStatus.values())
-                   .filter(status -> status.getValue().equalsIgnoreCase(value))
-                   .findFirst()
-                   .orElseThrow();
-    }
-
     public String getValue() {
         return value;
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
@@ -1,11 +1,7 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum TestApprovalStatus {
     APPROVED("Approved"), PENDING("Pending"), REJECTED("Rejected");
-
-    @JsonValue
     private final String value;
 
     TestApprovalStatus(String value) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+public enum TestApprovalStatus {
+    APPROVED("Approved"), PENDING("Pending"), REJECTED("Rejected");
+
+    @JsonValue
+    private final String value;
+
+    TestApprovalStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static TestApprovalStatus parse(String value) {
+        return Arrays.stream(TestApprovalStatus.values())
+                   .filter(status -> status.getValue().equalsIgnoreCase(value))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApprovalStatus.java
@@ -1,8 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Arrays;
 
 public enum TestApprovalStatus {
     APPROVED("Approved"), PENDING("Pending"), REJECTED("Rejected");

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -109,7 +109,7 @@ public record TestNviCandidate(String identifier,
             .append(approval.points()).append(DELIMITER)
             .append(calculateAffiliationPoints(affiliation)).append(DELIMITER)
             .append(approval.approvalStatus().getValue()).append(DELIMITER)
-            .append(globalApprovalStatus).append(DELIMITER)
+            .append(globalApprovalStatus.getValue()).append(DELIMITER)
             .append(reported ? reportingPeriod : "NotReported").append(DELIMITER)
             .append(totalPoints).append(DELIMITER)
             .append(publicationTypeChannelLevelPoints).append(DELIMITER)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -25,7 +25,7 @@ public record TestNviCandidate(String identifier,
                                BigDecimal internationalCollaborationFactor,
                                boolean reported,
                                String reportingPeriod,
-                               String globalApprovalStatus) {
+                               TestApprovalStatus globalApprovalStatus) {
 
     private static final String DELIMITER = ",";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
@@ -91,7 +91,7 @@ public record TestNviCandidate(String identifier,
                    .withInternationalCollaborationFactor(internationalCollaborationFactor.toString())
                    .withReported(reported)
                    .withReportingPeriod(new ReportingPeriodGenerator().withYear(reportingPeriod))
-                   .withGlobalApprovalStatus(globalApprovalStatus);
+                   .withGlobalApprovalStatus(globalApprovalStatus.getValue());
     }
 
     private void generateExpectedNviResponse(StringBuilder stringBuilder, TestNviContributor contributor) {
@@ -163,7 +163,7 @@ public record TestNviCandidate(String identifier,
         private BigDecimal internationalCollaborationFactor;
         private boolean reported;
         private String reportingPeriod;
-        private String globalApprovalStatus;
+        private TestApprovalStatus globalApprovalStatus;
 
         private Builder() {
         }
@@ -223,7 +223,7 @@ public record TestNviCandidate(String identifier,
             return this;
         }
 
-        public Builder withGlobalApprovalStatus(String globalApprovalStatus) {
+        public Builder withGlobalApprovalStatus(TestApprovalStatus globalApprovalStatus) {
             this.globalApprovalStatus = globalApprovalStatus;
             return this;
         }


### PR DESCRIPTION
Changes according to [Instruks for lesing av NVI-kontrolldata (Excel) for superbrukere](https://www.cristin.no/nvi-rapportering/nvi-veiledninger/hvordan_lese_nvi-kontrolldata.html)
- Rename `RAPPORTERT_STATUS` to `RAPPORTSTATUS`
- Bind values `J`,`N` or `?` to `RAPPORTSTATUS` depending on `globalApprovalStatus`