### PR TITLE
Np 46457 Nvi Institution status report, kvalitetsnivakode changes

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -97,7 +97,12 @@ SELECT DISTINCT
         ?reference :publicationContext ?publicationContext .
         ?publicationContext a ?channelTypeId ;
                             :name ?PUBLISERINGSKANALNAVN ;
-                            :scientificValue ?KVALITETSNIVAKODE .
+                            :scientificValue ?scientificValue .
+
+        BIND(
+          IF(?scientificValue = "LevelOne", "1",
+          IF(?scientificValue = "LevelTwo", "2", xsd:string(?scientificValue))) AS ?KVALITETSNIVAKODE
+        )
 
         BIND(REPLACE(STR(?publicationContext), "^.*/([^/]+)/[^/]+$", "$1") AS ?channelIdentifier)
         BIND(STR(?channelTypeId) AS ?channelType)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -34,6 +34,7 @@ import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestLevel;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestPublication;
 import nva.commons.core.paths.UriWrapper;
 
@@ -89,7 +90,7 @@ public final class NviInstitutionStatusTestData {
             .append(publication.getChannel().getType()
                         .substring(publication.getChannel().getType().indexOf("#") + 1)).append(DELIMITER)
             .append(publication.getChannel().getPrintIssn()).append(DELIMITER)
-            .append(publication.getChannel().getScientificValue()).append(DELIMITER)
+            .append(getExpectedPublicationChannelLevel(publication)).append(DELIMITER)
             .append(UriWrapper.fromUri(contributor.id()).getLastPathElement()).append(DELIMITER)
             .append(affiliation.getOrganizationNumber()).append(DELIMITER)
             .append(affiliation.getSubUnitOneNumber()).append(DELIMITER)
@@ -111,6 +112,14 @@ public final class NviInstitutionStatusTestData {
             .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
             .append(POINTS_FOR_AFFILIATION).append(CRLF.getString());//TODO: Implement
+    }
+
+    private static String getExpectedPublicationChannelLevel(TestPublication publication) {
+        var level = TestLevel.parse(publication.getChannel().getScientificValue());
+        return switch (level) {
+            case LEVEL_ONE -> "1";
+            case LEVEL_TWO -> "2";
+        };
     }
 
     private static TestApproval findExpectedApproval(TestNviOrganization affiliation, TestNviCandidate candidate) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/publication/TestLevel.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/publication/TestLevel.java
@@ -1,0 +1,24 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.publication;
+
+import java.util.Arrays;
+
+public enum TestLevel {
+    LEVEL_ONE("LevelOne"), LEVEL_TWO("LevelTwo");
+
+    private final String value;
+
+    TestLevel(String value) {
+        this.value = value;
+    }
+
+    public static TestLevel parse(String value) {
+        return Arrays.stream(TestLevel.values())
+                   .filter(level -> level.getValue().equalsIgnoreCase(value))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
Changes according to [Instruks for lesing av NVI-kontrolldata (Excel) for superbrukere](https://www.cristin.no/nvi-rapportering/nvi-veiledninger/hvordan_lese_nvi-kontrolldata.html)

Bind values `1` or `2` to `KVALITETSNIVAKODE` (instead of `LevelOne` or `LevelTwo`)