### PR TITLE
Np 46456 Nvi Institution report, status kontrollert changes

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -58,9 +58,15 @@ SELECT DISTINCT
 
        ?candidate :approval ?approval .
              ?approval a :Approval ;
-               :approvalStatus ?STATUS_KONTROLLERT ;
+               :approvalStatus ?approvalStatus ;
                :points ?institutionPoints ;
                :institutionId ?organizationUri .
+
+       BIND(
+          IF(?approvalStatus = "Pending", "?",
+          IF(?approvalStatus = "Approved", "J",
+          IF(?approvalStatus = "Rejected", "N", xsd:string(?approvalStatus)))) AS ?STATUS_KONTROLLERT
+       )
 
        FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
        FILTER (STR(?organizationUri) = "__REPLACE_WITH_TOP_LEVEL_ORGANIZATION__")

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -133,8 +133,8 @@ public final class NviInstitutionStatusTestData {
                    .orElse(null);
     }
 
-    private static String getExpectedApprovalStatusValue(TestApprovalStatus globalApprovalStatus) {
-        return switch (globalApprovalStatus) {
+    private static String getExpectedApprovalStatusValue(TestApprovalStatus approvalStatus) {
+        return switch (approvalStatus) {
             case APPROVED -> "J";
             case REJECTED -> "N";
             case PENDING -> "?";

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -7,12 +7,12 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstituti
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.DEPARTMENT_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.FACULTY_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.FIRST_NAME;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.GLOBAL_STATUS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.GROUP_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INSTITUTION_APPROVAL_STATUS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INSTITUTION_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INTERNATIONAL_COLLABORATION_FACTOR;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.ISSN;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.GLOBAL_STATUS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LANGUAGE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LAST_NAME;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PAGE_COUNT;
@@ -95,7 +95,7 @@ public final class NviInstitutionStatusTestData {
         var approval = getExpectedApproval(affiliation, candidate);
         var identity = getExpectedContributorIdentity(contributor, publication);
         stringBuilder.append(publication.getIdentifier()).append(DELIMITER)
-            .append(approval.approvalStatus().getValue()).append(DELIMITER)
+            .append(getExpectedApprovalStatusValue(approval.approvalStatus())).append(DELIMITER)
             .append(publication.getPublicationCategory()).append(DELIMITER)
             .append(publication.getChannel().getType()
                         .substring(publication.getChannel().getType().indexOf("#") + 1)).append(DELIMITER)
@@ -117,7 +117,7 @@ public final class NviInstitutionStatusTestData {
             .append(PAGE_COUNT).append(DELIMITER)//TODO: Implement
             .append(publication.getMainTitle()).append(DELIMITER)
             .append(LANGUAGE).append(DELIMITER)//TODO: Implement
-            .append(getExpectedGlobalStatus(candidate.globalApprovalStatus())).append(DELIMITER)
+            .append(getExpectedApprovalStatusValue(candidate.globalApprovalStatus())).append(DELIMITER)
             .append(candidate.publicationTypeChannelLevelPoints()).append(DELIMITER) //TODO: Check if correct
             .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
@@ -133,7 +133,7 @@ public final class NviInstitutionStatusTestData {
                    .orElse(null);
     }
 
-    private static String getExpectedGlobalStatus(TestApprovalStatus globalApprovalStatus) {
+    private static String getExpectedApprovalStatusValue(TestApprovalStatus globalApprovalStatus) {
         return switch (globalApprovalStatus) {
             case APPROVED -> "J";
             case REJECTED -> "N";


### PR DESCRIPTION
Changes according to [Instruks for lesing av NVI-kontrolldata (Excel) for superbrukere](https://www.cristin.no/nvi-rapportering/nvi-veiledninger/hvordan_lese_nvi-kontrolldata.html)

Bind values `J`,`N` or `?` to `STATUS_KONTROLLERT` depending on `approvalStatus`