### PR TITLE
Remove schema data types from results

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -36,9 +36,12 @@ SELECT DISTINCT
        ?candidate a :NviCandidate ;
                :publicationDetails ?publicationUri ;
                :isApplicable ?isApplicable ;
-               :internationalCollaborationFactor ?FAKTORTALL_SAMARBEID ;
+               :internationalCollaborationFactor ?internationalCollaborationFactor ;
                :globalApprovalStatus ?globalApprovalStatus ;
-               :publicationTypeChannelLevelPoints ?VEKTINGSTALL .
+               :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
+
+       BIND(STR(?internationalCollaborationFactor) AS ?FAKTORTALL_SAMARBEID) .
+       BIND(STR(?publicationTypeChannelLevelPoints) AS ?VEKTINGSTALL) .
 
        BIND(
          IF(?globalApprovalStatus = "Pending", "?",

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -25,9 +25,12 @@ WHERE {
         :isApplicable ?isApplicableBoolean ;
         :points ?totalPoints ;
         :globalApprovalStatus ?globalApprovalStatus ;
-        :internationalCollaborationFactor ?internationalCollaborationFactor ;
+        :internationalCollaborationFactor ?internationalCollaborationFactorDecimal ;
         :creatorShareCount ?authorShareCount ;
-        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
+        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPointsDecimal .
+
+      BIND(STR(?internationalCollaborationFactorDecimal) AS ?internationalCollaborationFactor) .
+      BIND(STR(?publicationTypeChannelLevelPointsDecimal) AS ?publicationTypeChannelLevelPoints) .
 
       OPTIONAL {
         ?candidate :reported ?reported ;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -118,8 +118,8 @@ public final class NviInstitutionStatusTestData {
             .append(publication.getMainTitle()).append(DELIMITER)
             .append(LANGUAGE).append(DELIMITER)//TODO: Implement
             .append(getExpectedApprovalStatusValue(candidate.globalApprovalStatus())).append(DELIMITER)
-            .append(candidate.publicationTypeChannelLevelPoints()).append(DELIMITER) //TODO: Check if correct
-            .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
+            .append(candidate.publicationTypeChannelLevelPoints().stripTrailingZeros()).append(DELIMITER)
+            .append(candidate.internationalCollaborationFactor().stripTrailingZeros()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
             .append(calculatePointsForAffiliation(affiliation, candidate, approval)).append(CRLF.getString());
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CandidateGenerator.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.Constants.ONTOLOGY_BASE_URI;
+import java.math.BigDecimal;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
 import org.apache.jena.datatypes.xsd.impl.XSDDateTimeType;
@@ -67,7 +68,7 @@ public class CandidateGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public CandidateGenerator withPublicationTypeChannelLevelPoints(String publicationTypeChannelLevelPoints) {
+    public CandidateGenerator withPublicationTypeChannelLevelPoints(BigDecimal publicationTypeChannelLevelPoints) {
         model.add(subject, PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS,
                   model.createTypedLiteral(publicationTypeChannelLevelPoints));
         return this;
@@ -78,7 +79,7 @@ public class CandidateGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public CandidateGenerator withInternationalCollaborationFactor(String internationalCollaborationFactor) {
+    public CandidateGenerator withInternationalCollaborationFactor(BigDecimal internationalCollaborationFactor) {
         model.add(subject, INTERNATIONAL_COLLABORATION_FACTOR,
                   model.createTypedLiteral(internationalCollaborationFactor));
         return this;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -86,9 +86,9 @@ public record TestNviCandidate(String identifier,
                    .withIsApplicable(isApplicable)
                    .withPublicationDetails(publicationDetails)
                    .withPoints(totalPoints.toString())
-                   .withPublicationTypeChannelLevelPoints(publicationTypeChannelLevelPoints.toString())
+                   .withPublicationTypeChannelLevelPoints(publicationTypeChannelLevelPoints)
                    .withCreatorShareCount(String.valueOf(creatorShareCount))
-                   .withInternationalCollaborationFactor(internationalCollaborationFactor.toString())
+                   .withInternationalCollaborationFactor(internationalCollaborationFactor)
                    .withReported(reported)
                    .withReportingPeriod(new ReportingPeriodGenerator().withYear(reportingPeriod))
                    .withGlobalApprovalStatus(globalApprovalStatus.getValue());
@@ -112,9 +112,9 @@ public record TestNviCandidate(String identifier,
             .append(globalApprovalStatus.getValue()).append(DELIMITER)
             .append(reported ? reportingPeriod : "NotReported").append(DELIMITER)
             .append(totalPoints).append(DELIMITER)
-            .append(publicationTypeChannelLevelPoints).append(DELIMITER)
+            .append(publicationTypeChannelLevelPoints.stripTrailingZeros()).append(DELIMITER)
             .append(creatorShareCount).append(DELIMITER)
-            .append(internationalCollaborationFactor).append(DELIMITER)
+            .append(internationalCollaborationFactor.stripTrailingZeros()).append(DELIMITER)
             .append(isApplicable())
             .append(CRLF.getString());
     }


### PR DESCRIPTION
Getting values like `1^^http://www.w3.org/2001/XMLSchema#integer` for `FAKTORTALL_SAMARBEID` and `VEKTINGSTALL` in the result

Bind `internationalCollaborationFactor` and `publicationTypeChannelLevelPoints` as strings