### PR TITLE
Np 46411 Nvi Institution report, add arstall and arstall_reg

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -4,7 +4,9 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 
 SELECT DISTINCT
+  ?ARSTALL
   ?VARBEIDLOPENR
+  ?ARSTALL_REG
   ?STATUS_KONTROLLERT
   ?PUBLIKASJONSFORM
   ?PUBLISERINGSKANALTYPE
@@ -38,7 +40,12 @@ SELECT DISTINCT
                :isApplicable ?isApplicable ;
                :internationalCollaborationFactor ?internationalCollaborationFactor ;
                :globalApprovalStatus ?globalApprovalStatus ;
-               :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
+               :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints ;
+               :reportingPeriod ?reportingPeriod .
+
+       ?reportingPeriod a :ReportingPeriod ;
+                        :year ?reportingYear .
+       BIND(STR(?reportingYear) AS ?ARSTALL)
 
        BIND(STR(?internationalCollaborationFactor) AS ?FAKTORTALL_SAMARBEID) .
        BIND(STR(?publicationTypeChannelLevelPoints) AS ?VEKTINGSTALL) .
@@ -122,12 +129,16 @@ SELECT DISTINCT
              :entityDescription ?entityDescription ;
              :entityDescription/:contributor ?contributor .
 
+        ?entityDescription :publicationDate ?publicationDate .
         ?entityDescription :mainTitle ?VA_TITTEL .
         ?entityDescription :reference ?reference .
         ?reference :publicationContext ?publicationContext .
         ?publicationContext a ?channelTypeId ;
                             :name ?PUBLISERINGSKANALNAVN ;
                             :scientificValue ?scientificValue .
+
+        ?publicationDate :year ?publicationYear .
+        BIND(STR(?publicationYear) AS ?ARSTALL_REG)
 
         BIND(
           IF(?scientificValue = "LevelOne", "1",

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
@@ -3,6 +3,8 @@ package no.sikt.nva.data.report.api.fetch.testutils.generator;
 public final class NviInstitutionStatusHeaders {
 
     public static String PUBLICATION_IDENTIFIER = "VARBEIDLOPENR";
+    public static String REPORTING_YEAR = "ARSTALL";
+    public static String PUBLISHED_YEAR = "ARSTALL_REG";
     public static String INSTITUTION_APPROVAL_STATUS = "STATUS_KONTROLLERT";//TODO: Check if this is correct
     public static String PUBLICATION_INSTANCE = "PUBLIKASJONSFORM";
     public static String PUBLICATION_CHANNEL_TYPE = "PUBLISERINGSKANALTYPE";

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -26,6 +26,8 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstituti
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_INSTANCE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_TITLE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLISHED_YEAR;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.REPORTING_YEAR;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.TOTAL_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestPublication.DELIMITER;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
@@ -49,7 +51,9 @@ public final class NviInstitutionStatusTestData {
     public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
     public static final int NVI_POINT_SCALE = 4;
 
-    public static final List<String> NVI_INSTITUTION_STATUS_HEADERS = List.of(PUBLICATION_IDENTIFIER,
+    public static final List<String> NVI_INSTITUTION_STATUS_HEADERS = List.of(REPORTING_YEAR,
+                                                                              PUBLICATION_IDENTIFIER,
+                                                                              PUBLISHED_YEAR,
                                                                               INSTITUTION_APPROVAL_STATUS,
                                                                               PUBLICATION_INSTANCE,
                                                                               PUBLICATION_CHANNEL_TYPE,
@@ -94,7 +98,9 @@ public final class NviInstitutionStatusTestData {
                                                                TestPublication publication) {
         var approval = getExpectedApproval(affiliation, candidate);
         var identity = getExpectedContributorIdentity(contributor, publication);
-        stringBuilder.append(publication.getIdentifier()).append(DELIMITER)
+        stringBuilder.append(candidate.reportingPeriod()).append(DELIMITER)
+            .append(publication.getIdentifier()).append(DELIMITER)
+            .append(publication.getDate().year()).append(DELIMITER)
             .append(getExpectedApprovalStatusValue(approval.approvalStatus())).append(DELIMITER)
             .append(publication.getPublicationCategory()).append(DELIMITER)
             .append(publication.getChannel().getType()


### PR DESCRIPTION
Added two new headers in report: `ARSTALL` and `ARSTALL_REG`. (See [instruks](https://www.cristin.no/nvi-rapportering/nvi-veiledninger/hvordan_lese_nvi-kontrolldata.html))
- Bind `publicationDate` `year` as `ARSTALL_REG`
- Bind `reportingPeriod` `year` as `ARSTALL`