### PR TITLE
Add global approval status Dispute

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -51,11 +51,12 @@ SELECT DISTINCT
        BIND(STR(?publicationTypeChannelLevelPoints) AS ?VEKTINGSTALL) .
 
        BIND(
-           IF(?globalApprovalStatus = "Pending", "?",
-           IF(?globalApprovalStatus = "Approved", "J",
-           IF(?globalApprovalStatus = "Dispute", "T",
-           IF(?globalApprovalStatus = "Rejected", "N",
-           xsd:string(?globalApprovalStatus))))) AS ?RAPPORTSTATUS
+          COALESCE (
+              IF(?globalApprovalStatus = "Pending", "?", ?ignored),
+              IF(?globalApprovalStatus = "Approved", "J", ?ignored),
+              IF(?globalApprovalStatus = "Dispute", "T", ?ignored),
+              IF(?globalApprovalStatus = "Rejected", "N", ?ignored)
+          ) AS ?RAPPORTSTATUS
        )
 
        BIND(REPLACE(STR(?publicationUri), "^.*/([^/]*)$", "$1") AS ?VARBEIDLOPENR)

--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -51,9 +51,11 @@ SELECT DISTINCT
        BIND(STR(?publicationTypeChannelLevelPoints) AS ?VEKTINGSTALL) .
 
        BIND(
-         IF(?globalApprovalStatus = "Pending", "?",
-         IF(?globalApprovalStatus = "Approved", "J",
-         IF(?globalApprovalStatus = "Rejected", "N", xsd:string(?globalApprovalStatus)))) AS ?RAPPORTSTATUS
+           IF(?globalApprovalStatus = "Pending", "?",
+           IF(?globalApprovalStatus = "Approved", "J",
+           IF(?globalApprovalStatus = "Dispute", "T",
+           IF(?globalApprovalStatus = "Rejected", "N",
+           xsd:string(?globalApprovalStatus))))) AS ?RAPPORTSTATUS
        )
 
        BIND(REPLACE(STR(?publicationUri), "^.*/([^/]*)$", "$1") AS ?VARBEIDLOPENR)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -36,6 +36,7 @@ import java.math.RoundingMode;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestGlobalApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
@@ -137,6 +138,15 @@ public final class NviInstitutionStatusTestData {
                    .filter(identity -> identity.uri().equals(contributor.id()))
                    .findFirst()
                    .orElse(null);
+    }
+
+    private static String getExpectedApprovalStatusValue(TestGlobalApprovalStatus approvalStatus) {
+        return switch (approvalStatus) {
+            case PENDING -> "?";
+            case APPROVED -> "J";
+            case REJECTED -> "N";
+            case DISPUTE -> "T";
+        };
     }
 
     private static String getExpectedApprovalStatusValue(TestApprovalStatus approvalStatus) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestGlobalApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate.Builder;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
@@ -201,7 +202,7 @@ public final class NviTestData {
                    .withApprovals(approvals)
                    .withCreatorShareCount(countCombinationsOfCreatorsAndAffiliations(publicationDetails))
                    .withInternationalCollaborationFactor(BigDecimal.ONE)
-                   .withGlobalApprovalStatus(TestApprovalStatus.PENDING)
+                   .withGlobalApprovalStatus(randomElement(TestGlobalApprovalStatus.values()))
                    .withPublicationTypeChannelLevelPoints(randomBigDecimal())
                    .withTotalPoints(randomBigDecimal())
                    .withReportingPeriod(reportingPeriod);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestGlobalApprovalStatus.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestGlobalApprovalStatus.java
@@ -1,0 +1,16 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
+
+public enum TestGlobalApprovalStatus {
+
+    APPROVED("Approved"), PENDING("Pending"), REJECTED("Rejected"), DISPUTE("Dispute");
+    private final String value;
+
+    TestGlobalApprovalStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -25,7 +25,7 @@ public record TestNviCandidate(String identifier,
                                BigDecimal internationalCollaborationFactor,
                                boolean reported,
                                String reportingPeriod,
-                               TestApprovalStatus globalApprovalStatus) {
+                               TestGlobalApprovalStatus globalApprovalStatus) {
 
     private static final String DELIMITER = ",";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
@@ -163,7 +163,7 @@ public record TestNviCandidate(String identifier,
         private BigDecimal internationalCollaborationFactor;
         private boolean reported;
         private String reportingPeriod;
-        private TestApprovalStatus globalApprovalStatus;
+        private TestGlobalApprovalStatus globalApprovalStatus;
 
         private Builder() {
         }
@@ -223,7 +223,7 @@ public record TestNviCandidate(String identifier,
             return this;
         }
 
-        public Builder withGlobalApprovalStatus(TestApprovalStatus globalApprovalStatus) {
+        public Builder withGlobalApprovalStatus(TestGlobalApprovalStatus globalApprovalStatus) {
             this.globalApprovalStatus = globalApprovalStatus;
             return this;
         }


### PR DESCRIPTION
- Add enum `TestGlobalApprovalStatus`
- Set `RAPPORTSTATUS` in nvi institution report to `"T"` if `globalApprovalStatus` is `Dispute`