### PR TITLE
Bump jena > 5.0.0

### DIFF
--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandlerTest.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.data.report.api.etl.loader;
 
 import static nva.commons.core.attempt.Try.attempt;
-import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,7 +20,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 class BulkLoadHandlerTest {
@@ -32,7 +30,7 @@ class BulkLoadHandlerTest {
     @Test
     void shouldLogSuccessfulLoadingEvent() throws IOException, InterruptedException {
         final var logger = LogUtils.getTestingAppenderForRootLogger();
-        var response = new Response(SC_OK, new SuccessPayload(UUID.randomUUID()));
+        var response = new Response(200, new SuccessPayload(UUID.randomUUID()));
         var httpClient = setUpSuccessfulHttpResponse(response);
         var handler = new BulkLoadHandler(httpClient);
         handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
@@ -44,7 +42,7 @@ class BulkLoadHandlerTest {
     @Test
     void shouldLogFailingLoadingEvent() throws IOException, InterruptedException {
         final var logger = LogUtils.getTestingAppenderForRootLogger();
-        var response = new Response(HttpStatus.SC_FORBIDDEN, new SuccessPayload(UUID.randomUUID()));
+        var response = new Response(403, new SuccessPayload(UUID.randomUUID()));
         var httpClient = setUpFailingHttpResponse(response);
         var handler = new BulkLoadHandler(httpClient);
         handler.handleRequest(new ByteArrayInputStream("{}".getBytes()),
@@ -75,7 +73,7 @@ class BulkLoadHandlerTest {
     }
 
     private Response createErrorResponseLogString(UUID uuid) {
-        return new Response(SC_OK, new ErrorPayload(uuid));
+        return new Response(200, new ErrorPayload(uuid));
     }
 
     private HttpClient setUpFailingHttpResponse(Response response)

--- a/data-report-commons/build.gradle
+++ b/data-report-commons/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation libs.nva.commons.core
     implementation libs.nva.json
     implementation libs.bundles.jena
+    implementation libs.bundles.jackson
     implementation libs.jena.core
     implementation libs.bundles.logging
     implementation libs.jena.rdfconnection

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ log4j = { strictly = '2.22.1' }
 slf4j = { strictly = '2.0.11' }
 awsSdk2 = { strictly = '2.23.12' }
 awsSdk2Events = { strictly = '3.11.4' }
-jena = { require = '4.10.0' }
+jena = { require = '5.0.0' }
 jackson = { require = '2.16.1' }
 guava = { strictly = '32.1.2-jre' }
 mockito = { strictly = '5.3.1' }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportProxy.java
@@ -25,7 +25,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.secrets.SecretsReader;
-import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +36,7 @@ public class FetchNviInstitutionReportProxy extends ApiGatewayHandler<Void, Stri
     private static final String BACKEND_CLIENT_AUTH_URL = "COGNITO_HOST";
     private static final String ACCEPT_HEADER = "Accept";
     private static final String PATH_PARAMETER_REPORTING_YEAR = "reportingYear";
+    public static final int OK = 200;
     private final NviInstitutionReportClient reportClient;
 
     @JacocoGenerated
@@ -70,7 +70,7 @@ public class FetchNviInstitutionReportProxy extends ApiGatewayHandler<Void, Stri
 
     @Override
     protected Integer getSuccessStatusCode(Void unused, String o) {
-        return HttpStatus.SC_OK;
+        return OK;
     }
 
     private static String encodeToString(InputStream inputStream) {

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/model/ReportRequest.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/model/ReportRequest.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.data.report.api.fetch.model;
 
+import static com.google.common.net.HttpHeaders.ACCEPT;
 import static java.util.Objects.nonNull;
-import static org.apache.http.HttpHeaders.ACCEPT;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import nva.commons.apigateway.RequestInfo;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchDataReportTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch;
 
+import static com.google.common.net.HttpHeaders.ACCEPT;
 import static java.lang.String.valueOf;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_CSV;
 import static no.sikt.nva.data.report.api.fetch.CustomMediaType.TEXT_PLAIN;
@@ -11,7 +12,6 @@ import static no.sikt.nva.data.report.api.fetch.testutils.ExcelAsserter.assertEq
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.PublicationHeaders.CONTRIBUTOR_IDENTIFIER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.PublicationHeaders.PUBLICATION_ID;
 import static nva.commons.apigateway.GatewayResponse.fromOutputStream;
-import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/FetchNviInstitutionReportTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch;
 
+import static com.google.common.net.HttpHeaders.ACCEPT;
 import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedCsvFormatter.generateTable;
 import static no.sikt.nva.data.report.api.fetch.formatter.ExpectedExcelFormatter.generateExcel;
 import static no.sikt.nva.data.report.api.fetch.formatter.ResultSorter.sortResponse;
@@ -10,7 +11,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.apigateway.GatewayResponse.fromOutputStream;
 import static nva.commons.core.attempt.Try.attempt;
-import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -124,8 +124,8 @@ public final class NviInstitutionStatusTestData {
             .append(publication.getMainTitle()).append(DELIMITER)
             .append(LANGUAGE).append(DELIMITER)//TODO: Implement
             .append(getExpectedApprovalStatusValue(candidate.globalApprovalStatus())).append(DELIMITER)
-            .append(candidate.publicationTypeChannelLevelPoints().stripTrailingZeros()).append(DELIMITER)
-            .append(candidate.internationalCollaborationFactor().stripTrailingZeros()).append(DELIMITER)
+            .append(candidate.publicationTypeChannelLevelPoints()).append(DELIMITER)
+            .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
             .append(calculatePointsForAffiliation(affiliation, candidate, approval)).append(CRLF.getString());
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -112,9 +112,9 @@ public record TestNviCandidate(String identifier,
             .append(globalApprovalStatus.getValue()).append(DELIMITER)
             .append(reported ? reportingPeriod : "NotReported").append(DELIMITER)
             .append(totalPoints).append(DELIMITER)
-            .append(publicationTypeChannelLevelPoints.stripTrailingZeros()).append(DELIMITER)
+            .append(publicationTypeChannelLevelPoints).append(DELIMITER)
             .append(creatorShareCount).append(DELIMITER)
-            .append(internationalCollaborationFactor.stripTrailingZeros()).append(DELIMITER)
+            .append(internationalCollaborationFactor).append(DELIMITER)
             .append(isApplicable())
             .append(CRLF.getString());
     }


### PR DESCRIPTION
- Bumping Jena from 4.x to 5.x creates a few issues due to a) transitive dependencies and b) (possibly due to java version — 17 is now required), management of BigDecimal.

As a result:

- Specify Jackson dependency directly
- Don't use apache HTTP values
- Allow trailing zeroes in values

Finally, I have included some literals here. We need to figure out if these are OK (in tests, I think "yes").