### PR TITLE
Np 46529 Refactor nvi points for affiliation

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -70,10 +70,18 @@ SELECT DISTINCT
              ?affiliationUri a ?NviOrganization .
 
        ?candidate :approval ?approval .
-             ?approval a :Approval ;
-               :approvalStatus ?approvalStatus ;
-               :points ?institutionPoints ;
-               :institutionId ?organizationUri .
+       ?approval a :Approval ;
+         :approvalStatus ?approvalStatus ;
+         :points ?institutionPoints ;
+         :institutionId ?organizationUri .
+
+       ?institutionPoints a :InstitutionPoints ;
+         :breakdown ?pointsBreakdown .
+
+       ?pointsBreakdown a :CreatorAffiliationPoints ;
+         :creatorId ?contributorIdString ;
+         :affiliationId ?affiliationId ;
+         :points ?FORFATTERVEKT .
 
        BIND(
           IF(?approvalStatus = "Pending", "?",
@@ -100,27 +108,6 @@ SELECT DISTINCT
        BIND("SPRAK" AS ?SPRAK)
        BIND("FORFATTERDEL" AS ?FORFATTERDEL)
        BIND("FORFATTERVEKT" AS ?VEKTET)
-
-       {
-         SELECT ?publicationUri ?organizationUri (COUNT(DISTINCT ?contributorId) AS ?numberOfAffiliationsForInstitution){
-           ?candidate a :NviCandidate ;
-                   :publicationDetails ?publicationUri ;
-                   :approval ?approval .
-
-           ?publicationUri :contributor ?contributorId .
-                 ?contributorId a :NviContributor .
-
-           ?contributorId :affiliation ?affiliationUri .
-           ?affiliationUri a ?NviOrganization .
-
-           ?approval a :Approval ;
-             :institutionId ?organizationUri .
-
-           FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
-         }
-         GROUP BY ?publicationUri ?organizationUri
-       }
-       BIND(STR(ROUND((xsd:decimal(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?FORFATTERVEKT)
 
        ?reportingPeriod a :ReportingPeriod ;
                         :year ?reportingYear .

--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -76,9 +76,9 @@ SELECT DISTINCT
          :institutionId ?organizationUri .
 
        ?institutionPoints a :InstitutionPoints ;
-         :breakdown ?pointsBreakdown .
+         :creatorAffiliationPoints ?creatorAffiliationPoints .
 
-       ?pointsBreakdown a :CreatorAffiliationPoints ;
+       ?creatorAffiliationPoints a :CreatorAffiliationPoints ;
          :creatorId ?contributorIdString ;
          :affiliationId ?affiliationId ;
          :points ?FORFATTERVEKT .

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -62,9 +62,9 @@ WHERE {
 
       ?institutionPointsNode a :InstitutionPoints ;
         :points ?institutionPoints ;
-        :breakdown ?pointsBreakdown .
+        :creatorAffiliationPoints ?creatorAffiliationPoints .
 
-      ?pointsBreakdown a :CreatorAffiliationPoints ;
+      ?creatorAffiliationPoints a :CreatorAffiliationPoints ;
         :creatorId ?contributorIdString ;
         :affiliationId ?affiliationId ;
         :points ?pointsForAffiliation .

--- a/report-api/src/main/resources/template/nvi.sparql
+++ b/report-api/src/main/resources/template/nvi.sparql
@@ -45,6 +45,7 @@ WHERE {
 
       ?publicationUri :contributor ?contributorId .
       ?contributorId a :NviContributor .
+      BIND(STR(?contributorId) AS ?contributorIdString)
       BIND(REPLACE(STR(?contributorId), "^.*/([^/]*)$", "$1") AS ?contributorIdentifier)
 
       ?contributorId :affiliation ?affiliationUri .
@@ -54,35 +55,22 @@ WHERE {
       ?candidate :approval ?approval .
       ?approval a :Approval ;
         :approvalStatus ?institutionApprovalStatus ;
-        :points ?institutionPoints ;
+        :points ?institutionPointsNode ;
         :institutionId ?organizationUri .
       FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
       BIND(STR(?organizationUri) AS ?institutionId)
 
+      ?institutionPointsNode a :InstitutionPoints ;
+        :points ?institutionPoints ;
+        :breakdown ?pointsBreakdown .
+
+      ?pointsBreakdown a :CreatorAffiliationPoints ;
+        :creatorId ?contributorIdString ;
+        :affiliationId ?affiliationId ;
+        :points ?pointsForAffiliation .
+
       FILTER(?modifiedDate >= "__AFTER__"^^xsd:dateTime)
       FILTER(?modifiedDate < "__BEFORE__"^^xsd:dateTime)
-
-      {
-        SELECT ?publicationUri ?organizationUri (COUNT(DISTINCT ?contributorId) AS ?numberOfAffiliationsForInstitution){
-          ?candidate a :NviCandidate ;
-                  :modifiedDate ?modifiedDate ;
-                  :publicationDetails ?publicationUri ;
-                  :approval ?approval .
-
-          ?publicationUri :contributor ?contributorId .
-                ?contributorId a :NviContributor .
-
-          ?contributorId :affiliation ?affiliationUri .
-          ?affiliationUri a ?NviOrganization .
-
-          ?approval a :Approval ;
-            :institutionId ?organizationUri .
-
-          FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
-        }
-        GROUP BY ?publicationUri ?organizationUri
-      }
-      BIND(STR(ROUND((xsd:decimal(?institutionPoints)*10000)/?numberOfAffiliationsForInstitution)/10000) AS ?pointsForAffiliation)
     }
     UNION
     {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/NviTestUtils.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/NviTestUtils.java
@@ -27,7 +27,7 @@ public final class NviTestUtils {
 
     private static boolean isForCreatorAndAffiliation(TestNviOrganization affiliation, TestNviContributor contributor,
                                                       TestCreatorAffiliationPoints creatorAffiliationPoints) {
-        return creatorAffiliationPoints.creatorId().toString().equals(contributor.id()) &&
-               creatorAffiliationPoints.affiliationId().toString().equals(affiliation.id());
+        return creatorAffiliationPoints.creatorId().toString().equals(contributor.id())
+               && creatorAffiliationPoints.affiliationId().toString().equals(affiliation.id());
     }
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/NviTestUtils.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/NviTestUtils.java
@@ -1,0 +1,33 @@
+package no.sikt.nva.data.report.api.fetch.testutils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestCreatorAffiliationPoints;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
+
+public final class NviTestUtils {
+
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+    private static final int NVI_POINT_SCALE = 4;
+
+    public static BigDecimal getExpectedPointsForAffiliation(TestNviOrganization affiliation,
+                                                             TestNviContributor contributor, TestApproval approval) {
+        return approval.points()
+                   .creatorAffiliationPoints()
+                   .stream()
+                   .filter(pointsForAffiliation -> isForCreatorAndAffiliation(affiliation, contributor,
+                                                                              pointsForAffiliation))
+                   .findFirst()
+                   .map(TestCreatorAffiliationPoints::points)
+                   .map(points -> points.stripTrailingZeros().setScale(NVI_POINT_SCALE, ROUNDING_MODE))
+                   .orElseThrow();
+    }
+
+    private static boolean isForCreatorAndAffiliation(TestNviOrganization affiliation, TestNviContributor contributor,
+                                                      TestCreatorAffiliationPoints creatorAffiliationPoints) {
+        return creatorAffiliationPoints.creatorId().toString().equals(contributor.id()) &&
+               creatorAffiliationPoints.affiliationId().toString().equals(affiliation.id());
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -31,16 +31,14 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstituti
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.TOTAL_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestPublication.DELIMITER;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
+import no.sikt.nva.data.report.api.fetch.testutils.NviTestUtils;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestGlobalApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviOrganization;
-import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestPublicationDetails;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestContributor;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestIdentity;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestLevel;
@@ -48,9 +46,6 @@ import no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestPub
 import nva.commons.core.paths.UriWrapper;
 
 public final class NviInstitutionStatusTestData {
-
-    public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
-    public static final int NVI_POINT_SCALE = 4;
 
     public static final List<String> NVI_INSTITUTION_STATUS_HEADERS = List.of(REPORTING_YEAR,
                                                                               PUBLICATION_IDENTIFIER,
@@ -128,7 +123,8 @@ public final class NviInstitutionStatusTestData {
             .append(candidate.publicationTypeChannelLevelPoints().stripTrailingZeros()).append(DELIMITER)
             .append(candidate.internationalCollaborationFactor().stripTrailingZeros()).append(DELIMITER)
             .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
-            .append(calculatePointsForAffiliation(affiliation, candidate, approval)).append(CRLF.getString());
+            .append(NviTestUtils.getExpectedPointsForAffiliation(affiliation, contributor, approval))
+            .append(CRLF.getString());
     }
 
     private static TestIdentity getExpectedContributorIdentity(TestNviContributor contributor,
@@ -176,21 +172,5 @@ public final class NviInstitutionStatusTestData {
         return approval.institutionId()
                    .toString()
                    .equals(organization.getTopLevelOrganization());
-    }
-
-    private static BigDecimal calculatePointsForAffiliation(TestNviOrganization affiliation, TestNviCandidate candidate,
-                                                            TestApproval approval) {
-        var topLevelOrganization = affiliation.getTopLevelOrganization();
-        var contributorCount = countNumberOfContributorsWithTopLevelAffiliation(topLevelOrganization,
-                                                                                candidate.publicationDetails());
-        return null;
-    }
-
-    private static long countNumberOfContributorsWithTopLevelAffiliation(String topLevelOrganization,
-                                                                         TestPublicationDetails publicationDetails) {
-        return publicationDetails.contributors().stream()
-                   .flatMap(contributor -> contributor.affiliations().stream())
-                   .filter(affiliation -> affiliation.getTopLevelOrganization().equals(topLevelOrganization))
-                   .count();
     }
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -183,9 +183,7 @@ public final class NviInstitutionStatusTestData {
         var topLevelOrganization = affiliation.getTopLevelOrganization();
         var contributorCount = countNumberOfContributorsWithTopLevelAffiliation(topLevelOrganization,
                                                                                 candidate.publicationDetails());
-        return approval.points().divide(BigDecimal.valueOf(contributorCount), ROUNDING_MODE)
-                   .setScale(NVI_POINT_SCALE, ROUNDING_MODE)
-                   .stripTrailingZeros();
+        return null;
     }
 
     private static long countNumberOfContributorsWithTopLevelAffiliation(String topLevelOrganization,

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -30,7 +30,9 @@ import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestCreatorAffiliationPoints;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestGlobalApprovalStatus;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestInstitutionPoints;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviCandidate.Builder;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestNviContributor;
@@ -179,14 +181,49 @@ public final class NviTestData {
                    .flatMap(contributor -> contributor.affiliations().stream())
                    .map(TestNviOrganization::getTopLevelOrganization)
                    .distinct()
-                   .map(NviTestData::generateApproval)
+                   .map(topLevelOrganization -> generateApproval(topLevelOrganization, publicationDetails))
                    .toList();
     }
 
-    private static TestApproval generateApproval(String topLevelOrganization) {
+    private static TestApproval generateApproval(String topLevelOrganization,
+                                                 TestPublicationDetails publicationDetails) {
+        var nviContributors = publicationDetails.filterContributorsWithTopLevelOrg(topLevelOrganization);
         return TestApproval.builder()
                    .withInstitutionId(URI.create(topLevelOrganization))
                    .withApprovalStatus(randomElement(TestApprovalStatus.values()))
+                   .withPoints(generateInstitutionPoints(topLevelOrganization, nviContributors))
+                   .build();
+    }
+
+    private static TestInstitutionPoints generateInstitutionPoints(String topLevelOrganization,
+                                                                   List<TestNviContributor> nviContributors) {
+        return TestInstitutionPoints.builder()
+                   .withCreatorAffiliationPoints(generateCreatorAffiliationPointsList(topLevelOrganization,
+                                                                                      nviContributors))
+                   .withPoints(randomBigDecimal())
+                   .build();
+    }
+
+    private static List<TestCreatorAffiliationPoints> generateCreatorAffiliationPointsList(String topLevelOrganization,
+                                                                                           List<TestNviContributor> nviContributors) {
+        return nviContributors.stream()
+                   .map(creator -> getCreatorAffiliationPoints(topLevelOrganization, creator))
+                   .flatMap(List::stream)
+                   .toList();
+    }
+
+    private static List<TestCreatorAffiliationPoints> getCreatorAffiliationPoints(String topLevelOrganization,
+                                                                                  TestNviContributor creator) {
+        return creator.filterAffiliationsWithTopLevelOrg(topLevelOrganization).stream()
+                   .map(affiliation -> generateCreatorAffiliationPoints(creator, affiliation))
+                   .toList();
+    }
+
+    private static TestCreatorAffiliationPoints generateCreatorAffiliationPoints(TestNviContributor creator,
+                                                                                 TestNviOrganization affiliation) {
+        return TestCreatorAffiliationPoints.builder()
+                   .withCreatorId(URI.create(creator.id()))
+                   .withAffiliationId(URI.create(affiliation.id()))
                    .withPoints(randomBigDecimal())
                    .build();
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -204,8 +204,9 @@ public final class NviTestData {
                    .build();
     }
 
-    private static List<TestCreatorAffiliationPoints> generateCreatorAffiliationPointsList(String topLevelOrganization,
-                                                                                           List<TestNviContributor> nviContributors) {
+    private static List<TestCreatorAffiliationPoints> generateCreatorAffiliationPointsList(
+        String topLevelOrganization,
+        List<TestNviContributor> nviContributors) {
         return nviContributors.stream()
                    .map(creator -> getCreatorAffiliationPoints(topLevelOrganization, creator))
                    .flatMap(List::stream)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -27,7 +27,7 @@ public class ApprovalGenerator extends TripleBasedBuilder {
 
     public ApprovalGenerator withInstitutionId(OrganizationGenerator organizationGenerator) {
         model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, INSTITUTION_ID),
-                  organizationGenerator.subject);
+                  organizationGenerator.getSubject());
         return this;
     }
 
@@ -36,8 +36,9 @@ public class ApprovalGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public ApprovalGenerator withPoints(String points) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, POINTS), points);
+    public ApprovalGenerator withPoints(InstitutionPointsGenerator institutionPointsGenerator) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, POINTS), institutionPointsGenerator.getSubject());
+        model.add(institutionPointsGenerator.build());
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -12,10 +12,10 @@ import org.apache.jena.rdf.model.impl.PropertyImpl;
 
 public class ApprovalGenerator extends TripleBasedBuilder {
 
+    public static final PropertyImpl POINTS_PROPERTY = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points");
+    public static final PropertyImpl APPROVAL_STATUS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "approvalStatus");
+    public static final PropertyImpl INSTITUTION_ID = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId");
     private static final Property APPROVAL = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "Approval");
-    private static final String INSTITUTION_ID = "institutionId";
-    private static final String APPROVAL_STATUS = "approvalStatus";
-    private static final String POINTS = "points";
     private final Model model;
     private final Resource subject;
 
@@ -26,18 +26,17 @@ public class ApprovalGenerator extends TripleBasedBuilder {
     }
 
     public ApprovalGenerator withInstitutionId(OrganizationGenerator organizationGenerator) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, INSTITUTION_ID),
-                  organizationGenerator.getSubject());
+        model.add(subject, INSTITUTION_ID, organizationGenerator.getSubject());
         return this;
     }
 
     public ApprovalGenerator withApprovalStatus(String approvalStatus) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, APPROVAL_STATUS), approvalStatus);
+        model.add(subject, APPROVAL_STATUS, approvalStatus);
         return this;
     }
 
     public ApprovalGenerator withPoints(InstitutionPointsGenerator institutionPointsGenerator) {
-        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, POINTS), institutionPointsGenerator.getSubject());
+        model.add(subject, POINTS_PROPERTY, institutionPointsGenerator.getSubject());
         model.add(institutionPointsGenerator.build());
         return this;
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CreatorAffiliationPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CreatorAffiliationPointsGenerator.java
@@ -1,0 +1,52 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
+
+import java.util.UUID;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+
+public class CreatorAffiliationPointsGenerator extends TripleBasedBuilder {
+
+    public static final PropertyImpl CREATOR_ID = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "creatorId");
+    public static final PropertyImpl AFFILIATION_ID = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "affiliationId");
+    public static final PropertyImpl POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points");
+    private static final Property CREATOR_AFFILIATION_POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
+                                                                                "CreatorAffiliationPoints");
+    private final Model model;
+    private final Resource subject;
+
+    public CreatorAffiliationPointsGenerator() {
+        this.model = ModelFactory.createDefaultModel();
+        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
+        model.add(subject, TYPE, CREATOR_AFFILIATION_POINTS);
+    }
+
+    public CreatorAffiliationPointsGenerator withCreatorId(String creatorId) {
+        model.add(subject, CREATOR_ID, creatorId);
+        return this;
+    }
+
+    public CreatorAffiliationPointsGenerator withAffiliationId(String affiliationId) {
+        model.add(subject, AFFILIATION_ID, affiliationId);
+        return this;
+    }
+
+    public CreatorAffiliationPointsGenerator withPoints(String points) {
+        model.add(subject, POINTS, points);
+        return this;
+    }
+
+    @Override
+    public Model build() {
+        return model;
+    }
+
+    @Override
+    public Resource getSubject() {
+        return subject;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
@@ -1,0 +1,47 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
+
+import java.util.UUID;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+
+public class InstitutionPointsGenerator extends TripleBasedBuilder {
+
+    public static final PropertyImpl BREAKDOWN = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "breakdown");
+    private static final Property INSTITUTION_POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
+                                                                        "institutionPoints");
+    private final Model model;
+    private final Resource subject;
+
+    public InstitutionPointsGenerator() {
+        this.model = ModelFactory.createDefaultModel();
+        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
+        model.add(subject, TYPE, INSTITUTION_POINTS);
+    }
+
+    public InstitutionPointsGenerator withPoints(String points) {
+        model.add(subject, new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points"), points);
+        return this;
+    }
+
+    public InstitutionPointsGenerator withCreatorAffiliationPoints(
+        CreatorAffiliationPointsGenerator creatorAffiliationPointsGenerator) {
+        model.add(subject, BREAKDOWN, creatorAffiliationPointsGenerator.getSubject());
+        model.add(creatorAffiliationPointsGenerator.build());
+        return this;
+    }
+
+    @Override
+    public Model build() {
+        return model;
+    }
+
+    @Override
+    public Resource getSubject() {
+        return subject;
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
@@ -13,7 +13,7 @@ public class InstitutionPointsGenerator extends TripleBasedBuilder {
 
     public static final PropertyImpl BREAKDOWN = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "breakdown");
     private static final Property INSTITUTION_POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
-                                                                        "institutionPoints");
+                                                                        "InstitutionPoints");
     private final Model model;
     private final Resource subject;
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
@@ -11,7 +11,8 @@ import org.apache.jena.rdf.model.impl.PropertyImpl;
 
 public class InstitutionPointsGenerator extends TripleBasedBuilder {
 
-    public static final PropertyImpl BREAKDOWN = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "breakdown");
+    public static final PropertyImpl CREATOR_AFFILIATION_POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
+                                                                                   "creatorAffiliationPoints");
     private static final Property INSTITUTION_POINTS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
                                                                         "InstitutionPoints");
     private final Model model;
@@ -28,11 +29,10 @@ public class InstitutionPointsGenerator extends TripleBasedBuilder {
         return this;
     }
 
-    public InstitutionPointsGenerator withCreatorAffiliationPoints(
+    public void withCreatorAffiliationPoints(
         CreatorAffiliationPointsGenerator creatorAffiliationPointsGenerator) {
-        model.add(subject, BREAKDOWN, creatorAffiliationPointsGenerator.getSubject());
+        model.add(subject, CREATOR_AFFILIATION_POINTS, creatorAffiliationPointsGenerator.getSubject());
         model.add(creatorAffiliationPointsGenerator.build());
-        return this;
     }
 
     @Override

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
@@ -6,7 +6,7 @@ import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalG
 
 public record TestApproval(URI institutionId,
                            TestApprovalStatus approvalStatus,
-                           BigDecimal points) {
+                           TestInstitutionPoints points) {
 
     public static Builder builder() {
         return new Builder();
@@ -20,7 +20,7 @@ public record TestApproval(URI institutionId,
 
         private URI institutionId;
         private TestApprovalStatus approvalStatus;
-        private BigDecimal points;
+        private TestInstitutionPoints points;
 
         private Builder() {
         }
@@ -35,7 +35,7 @@ public record TestApproval(URI institutionId,
             return this;
         }
 
-        public Builder withPoints(BigDecimal points) {
+        public Builder withPoints(TestInstitutionPoints points) {
             this.points = points;
             return this;
         }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestCreatorAffiliationPoints.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestCreatorAffiliationPoints.java
@@ -1,0 +1,47 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.CreatorAffiliationPointsGenerator;
+
+public record TestCreatorAffiliationPoints(URI creatorId,
+                                           URI affiliationId,
+                                           BigDecimal points) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public CreatorAffiliationPointsGenerator toModel() {
+        return new CreatorAffiliationPointsGenerator();
+    }
+
+    public static final class Builder {
+
+        private URI creatorId;
+        private URI affiliationId;
+        private BigDecimal points;
+
+        private Builder() {
+        }
+
+        public Builder withCreatorId(URI creatorId) {
+            this.creatorId = creatorId;
+            return this;
+        }
+
+        public Builder withAffiliationId(URI affiliationId) {
+            this.affiliationId = affiliationId;
+            return this;
+        }
+
+        public Builder withPoints(BigDecimal points) {
+            this.points = points;
+            return this;
+        }
+
+        public TestCreatorAffiliationPoints build() {
+            return new TestCreatorAffiliationPoints(creatorId, affiliationId, points);
+        }
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestInstitutionPoints.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestInstitutionPoints.java
@@ -1,0 +1,40 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
+
+import java.math.BigDecimal;
+import java.util.List;
+import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.InstitutionPointsGenerator;
+
+public record TestInstitutionPoints(BigDecimal points,
+                                    List<TestCreatorAffiliationPoints> creatorAffiliationPoints) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public InstitutionPointsGenerator toModel() {
+        return new InstitutionPointsGenerator();
+    }
+
+    public static final class Builder {
+
+        private BigDecimal points;
+        private List<TestCreatorAffiliationPoints> creatorAffiliationPoints;
+
+        private Builder() {
+        }
+
+        public Builder withPoints(BigDecimal points) {
+            this.points = points;
+            return this;
+        }
+
+        public Builder withCreatorAffiliationPoints(List<TestCreatorAffiliationPoints> creatorAffiliationPoints) {
+            this.creatorAffiliationPoints = creatorAffiliationPoints;
+            return this;
+        }
+
+        public TestInstitutionPoints build() {
+            return new TestInstitutionPoints(points, creatorAffiliationPoints);
+        }
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -1,10 +1,8 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
 import static no.sikt.nva.data.report.api.fetch.testutils.NviTestUtils.getExpectedPointsForAffiliation;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviTestData.randomBigDecimal;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.math.BigDecimal;
-import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
@@ -53,31 +51,6 @@ public record TestNviCandidate(String identifier,
         var nviCandidate = getCandidateGenerator(publicationDetails);
         addApprovals(nviCandidate);
         return nviCandidate.build();
-    }
-
-    private static void addAllCreatorAffiliationPoints(URI institutionId,
-                                                       InstitutionPointsGenerator institutionPointsGenerator,
-                                                       TestNviContributor creator) {
-        creator.filterAffiliationsWithTopLevelOrg(institutionId.toString())
-            .forEach(
-                affiliation -> addCreatorAffiliationPoints(institutionPointsGenerator,
-                                                           creator, affiliation));
-    }
-
-    private static void addCreatorAffiliationPoints(InstitutionPointsGenerator institutionPointsGenerator,
-                                                    TestNviContributor creator,
-                                                    TestNviOrganization affiliation) {
-        institutionPointsGenerator.withCreatorAffiliationPoints(generateCreatorAffiliationPoints(creator, affiliation,
-                                                                                                 randomBigDecimal()));
-    }
-
-    private static CreatorAffiliationPointsGenerator generateCreatorAffiliationPoints(TestNviContributor creator,
-                                                                                      TestNviOrganization affiliation,
-                                                                                      BigDecimal points) {
-        return new CreatorAffiliationPointsGenerator()
-                   .withAffiliationId(affiliation.id())
-                   .withCreatorId(creator.id())
-                   .withPoints(points.toString());
     }
 
     private ApprovalGenerator getApprovalGenerator(TestApproval testApproval) {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviContributor.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviContributor.java
@@ -6,6 +6,12 @@ import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.NviContri
 public record TestNviContributor(String id,
                                  List<TestNviOrganization> affiliations) {
 
+    public List<TestNviOrganization> filterAffiliationsWithTopLevelOrg(String institutionId) {
+        return affiliations.stream()
+                   .filter(affiliation -> affiliation.getTopLevelOrganization().equals(institutionId))
+                   .toList();
+    }
+
     public NviContributorGenerator toModel() {
         var contributor = new NviContributorGenerator(id);
         affiliations.stream().map(TestNviOrganization::toModel)

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviContributor.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviContributor.java
@@ -8,8 +8,12 @@ public record TestNviContributor(String id,
 
     public List<TestNviOrganization> filterAffiliationsWithTopLevelOrg(String institutionId) {
         return affiliations.stream()
-                   .filter(affiliation -> affiliation.getTopLevelOrganization().equals(institutionId))
+                   .filter(affiliation -> hasTopLevelOrg(affiliation, institutionId))
                    .toList();
+    }
+
+    private static boolean hasTopLevelOrg(TestNviOrganization organization, String topLevelOrgId) {
+        return organization.getTopLevelOrganization().equals(topLevelOrgId);
     }
 
     public NviContributorGenerator toModel() {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestPublicationDetails.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestPublicationDetails.java
@@ -8,6 +8,22 @@ public record TestPublicationDetails(String id, List<TestNviContributor> contrib
         return new Builder();
     }
 
+    public List<TestNviContributor> filterContributorsWithTopLevelOrg(String institutionId) {
+        return contributors.stream()
+                   .filter(contributor -> isAffiliatedToTopLevelOrg(contributor, institutionId))
+                   .toList();
+    }
+
+    private static boolean isAffiliatedToTopLevelOrg(TestNviContributor contributor, String institutionId) {
+        return contributor.affiliations()
+                   .stream()
+                   .anyMatch(affiliation -> hasTopLevelOrg(affiliation, institutionId));
+    }
+
+    private static boolean hasTopLevelOrg(TestNviOrganization affiliation, String institutionId) {
+        return affiliation.getTopLevelOrganization().equals(institutionId);
+    }
+
     public static final class Builder {
 
         private String id;


### PR DESCRIPTION
Instead of calculating points per affiliation with sparql, this is now available in the index data model (See [latest changes](https://github.com/BIBSYSDEV/nva-nvi/pull/289) in nva-nvi repo). This will reduce complexity and optimize query.

- Update model for `InstitutionPoints` and `CreatorAffiliationPoints` in test data
- Update sparql queries