### PR TITLE
BulkTransformer, replace event bridge with sqs client

### DIFF
--- a/bulk-load/build.gradle
+++ b/bulk-load/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation libs.aws.sdk2.sqs
     implementation libs.aws.lambda.events
     implementation libs.aws.sdk2.urlconnection
+    implementation libs.aws.sdk2.apache.client
     implementation libs.nva.identifiers
 
     testImplementation(libs.nva.testutils) {

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/aws/AwsSqsClient.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/aws/AwsSqsClient.java
@@ -1,0 +1,49 @@
+package no.sikt.nva.data.report.api.etl.aws;
+
+import no.sikt.nva.data.report.api.etl.queue.MessageResponse;
+import no.sikt.nva.data.report.api.etl.queue.QueueClient;
+import java.time.Duration;
+import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+@JacocoGenerated
+public class AwsSqsClient implements QueueClient {
+
+    private static final int MAX_CONNECTIONS = 10_000;
+    private static final int IDLE_TIME = 30;
+    private static final int TIMEOUT_TIME = 30;
+    private final String queueUrl;
+    private final SqsClient sqsClient;
+
+    public AwsSqsClient(Region region, String queueUrl) {
+        this.sqsClient = defaultSqsClient(region);
+        this.queueUrl = queueUrl;
+    }
+
+    @Override
+    public MessageResponse sendMessage(String body) {
+        var messageRequest = SendMessageRequest.builder().messageBody(body).queueUrl(queueUrl).build();
+        var response = sqsClient.sendMessage(messageRequest);
+        return new MessageResponse(response.messageId());
+    }
+
+    protected static SqsClient defaultSqsClient(Region region) {
+        return SqsClient.builder()
+                   .region(region)
+                   .httpClient(httpClientForConcurrentQueries())
+                   .build();
+    }
+
+    private static SdkHttpClient httpClientForConcurrentQueries() {
+        return ApacheHttpClient.builder()
+                   .useIdleConnectionReaper(true)
+                   .maxConnections(MAX_CONNECTIONS)
+                   .connectionMaxIdleTime(Duration.ofSeconds(IDLE_TIME))
+                   .connectionTimeout(Duration.ofSeconds(TIMEOUT_TIME))
+                   .build();
+    }
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/queue/MessageResponse.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/queue/MessageResponse.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.data.report.api.etl.queue;
+
+public record MessageResponse(String messageId) {
+
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/queue/QueueClient.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/queue/QueueClient.java
@@ -1,0 +1,6 @@
+package no.sikt.nva.data.report.api.etl.queue;
+
+public interface QueueClient {
+
+    MessageResponse sendMessage(String body);
+}

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandler.java
@@ -6,14 +6,15 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.JsonNode;
 import commons.db.utils.DocumentUnwrapper;
+import no.sikt.nva.data.report.api.etl.queue.QueueClient;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import no.sikt.nva.data.report.api.etl.aws.AwsSqsClient;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.s3.S3Driver;
@@ -23,10 +24,7 @@ import nva.commons.core.paths.UnixPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
@@ -36,13 +34,11 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
 
     private static final Logger logger = LoggerFactory.getLogger(BulkTransformerHandler.class);
     private static final Environment ENVIRONMENT = new Environment();
-    private static final String MANDATORY_UNUSED_SUBTOPIC = "DETAIL.WITH.TOPIC";
+    public static final String API_HOST = ENVIRONMENT.readEnv("API_HOST");
     private static final String LOADER_BUCKET = "LOADER_BUCKET";
     private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     private static final String NQUADS_GZIPPED = ".nquads.gz";
-    private static final String KEY_BATCHES_BUCKET
-        = ENVIRONMENT.readEnv("KEY_BATCHES_BUCKET");
-    private static final String EVENT_BUS = ENVIRONMENT.readEnv("EVENT_BUS");
+    private static final String KEY_BATCHES_BUCKET = ENVIRONMENT.readEnv("KEY_BATCHES_BUCKET");
     private static final String TOPIC = ENVIRONMENT.readEnv("TOPIC");
     private static final String PROCESSING_BATCH_MESSAGE = "Processing batch: {}";
     private static final String LAST_CONSUMED_BATCH = "Last consumed batch: {}";
@@ -50,26 +46,27 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
     private static final String ID_POINTER = "/id";
     private static final String NT_EXTENSION = ".nt";
     private static final String MISSING_ID_NODE_IN_CONTENT_ERROR = "Missing id-node in content: {}";
-    public static final String API_HOST = ENVIRONMENT.readEnv("API_HOST");
+    private static final String REGION = "AWS_REGION_NAME";
+    private static final String QUEUE_URL = "BULK_TRANSFORMER_QUEUE_URL";
     private final S3Client s3ResourcesClient;
     private final S3Client s3BatchesClient;
     private final S3Client s3OutputClient;
-    private final EventBridgeClient eventBridgeClient;
+    private final QueueClient queueClient;
 
     @JacocoGenerated
     public BulkTransformerHandler() {
-        this(defaultS3Client(), defaultS3Client(), defaultS3Client(), defaultEventBridgeClient());
+        this(defaultS3Client(), defaultS3Client(), defaultS3Client(), defaultSqsClient(new Environment()));
     }
 
     public BulkTransformerHandler(S3Client s3ResourcesClient,
                                   S3Client s3BatchesClient,
                                   S3Client s3OutputClient,
-                                  EventBridgeClient eventBridgeClient) {
+                                  QueueClient queueClient) {
         super(KeyBatchRequestEvent.class);
         this.s3ResourcesClient = s3ResourcesClient;
         this.s3BatchesClient = s3BatchesClient;
         this.s3OutputClient = s3OutputClient;
-        this.eventBridgeClient = eventBridgeClient;
+        this.queueClient = queueClient;
     }
 
     @Override
@@ -80,8 +77,6 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
         var location = getLocation(input);
         var batchResponse = fetchSingleBatch(startMarker);
 
-        emitNextEvent(batchResponse, location, context);
-
         batchResponse.getKey()
             .map(this::extractContent)
             .filter(keys -> !keys.isEmpty())
@@ -91,36 +86,18 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
             .map(this::persistNquads);
 
         logger.info(LAST_CONSUMED_BATCH, batchResponse.getKey());
+
+        if (batchResponse.isTruncated()) {
+            sendNewKeyBatchEvent(batchResponse.getKey().orElse(null), location);
+        }
         return null;
     }
 
-    private String aggregateNquads(Stream<JsonNode> element) {
-        return element.map(this::mapToNquads)
-                   .collect(Collectors.joining(System.lineSeparator()));
-    }
-
-    private void emitNextEvent(ListingResponse batchResponse,
-                                 String location,
-                                 Context context) {
-        if (batchResponse.isTruncated()) {
-            sendEvent(constructRequestEntry(batchResponse.getKey().orElse(null),
-                                            location,
-                                            context));
-        }
-    }
-
-    private static PutEventsRequestEntry constructRequestEntry(String lastEvaluatedKey,
-                                                               String location,
-                                                               Context context) {
-        return PutEventsRequestEntry.builder()
-                   .eventBusName(EVENT_BUS)
-                   .detail(new KeyBatchRequestEvent(lastEvaluatedKey, TOPIC, location)
-                               .toJsonString())
-                   .detailType(MANDATORY_UNUSED_SUBTOPIC)
-                   .source(BulkTransformerHandler.class.getName())
-                   .resources(context.getInvokedFunctionArn())
-                   .time(Instant.now())
-                   .build();
+    @JacocoGenerated
+    private static AwsSqsClient defaultSqsClient(Environment environment) {
+        var region = environment.readEnv(REGION);
+        var queueUrl = environment.readEnv(QUEUE_URL);
+        return new AwsSqsClient(Region.of(region), queueUrl);
     }
 
     private static String getStartMarker(KeyBatchRequestEvent input) {
@@ -132,9 +109,22 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
         return S3Driver.defaultS3Client().build();
     }
 
-    @JacocoGenerated
-    private static EventBridgeClient defaultEventBridgeClient() {
-        return EventBridgeClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
+    private static URI extractGraphName(JsonNode content) {
+        var id = content.at(ID_POINTER);
+        if (id.isMissingNode()) {
+            logger.error(MISSING_ID_NODE_IN_CONTENT_ERROR, content);
+            throw new MissingIdException();
+        }
+        return URI.create(id.textValue() + NT_EXTENSION);
+    }
+
+    private void sendNewKeyBatchEvent(String batchResponse, String location) {
+        queueClient.sendMessage(new KeyBatchRequestEvent(batchResponse, TOPIC, location).toJsonString());
+    }
+
+    private String aggregateNquads(Stream<JsonNode> element) {
+        return element.map(this::mapToNquads)
+                   .collect(Collectors.joining(System.lineSeparator()));
     }
 
     private boolean persistNquads(byte[] nquads) {
@@ -148,15 +138,6 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
 
     private String mapToNquads(JsonNode content) {
         return Nquads.transform(content.toString(), extractGraphName(content)).toString();
-    }
-
-    private static URI extractGraphName(JsonNode content) {
-        var id = content.at(ID_POINTER);
-        if (id.isMissingNode()) {
-            logger.error(MISSING_ID_NODE_IN_CONTENT_ERROR, content);
-            throw new MissingIdException();
-        }
-        return URI.create(id.textValue() + NT_EXTENSION);
     }
 
     private String extractContent(String key) {
@@ -177,10 +158,6 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
                 .maxKeys(1)
                 .build());
         return new ListingResponse(response);
-    }
-
-    private void sendEvent(PutEventsRequestEntry event) {
-        eventBridgeClient.putEvents(PutEventsRequest.builder().entries(event).build());
     }
 
     private Stream<JsonNode> mapToIndexDocuments(String content) {
@@ -216,17 +193,17 @@ public class BulkTransformerHandler extends EventHandler<KeyBatchRequestEvent, V
             this.key = extractKey(response);
         }
 
-        private static String extractKey(ListObjectsV2Response response) {
-            var contents = response.contents();
-            return contents.isEmpty() ? null : contents.getFirst().key();
-        }
-
         public boolean isTruncated() {
             return truncated;
         }
 
         public Optional<String> getKey() {
             return Optional.ofNullable(key);
+        }
+
+        private static String extractKey(ListObjectsV2Response response) {
+            var contents = response.contents();
+            return contents.isEmpty() ? null : contents.getFirst().key();
         }
     }
 }

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
@@ -1,11 +1,11 @@
 package no.sikt.nva.data.report.api.etl.transformer;
 
 import static java.util.UUID.randomUUID;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -23,12 +23,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import no.sikt.nva.data.report.api.etl.transformer.model.EventConsumptionAttributes;
 import no.sikt.nva.data.report.api.etl.transformer.model.IndexDocument;
-import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
-import nva.commons.core.SingletonCollector;
 import nva.commons.core.StringUtils;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UnixPath;
@@ -36,14 +34,11 @@ import nva.commons.logutils.LogUtils;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
-import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
-import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
 import software.amazon.awssdk.services.s3.S3Client;
 
 class BulkTransformerHandlerTest {
@@ -51,27 +46,30 @@ class BulkTransformerHandlerTest {
     private static final String IDENTIFIER = "__IDENTIFIER__";
     private static final String VALID_PUBLICATION = IoUtils.stringFromResources(Path.of("publication.json"));
     private static final String DEFAULT_LOCATION = "resources";
-    private static final ObjectMapper objectMapperWithEmpty = JsonUtils.dtoObjectMapper;
+    private static final ObjectMapper objectMapperWithEmpty = dtoObjectMapper;
     private ByteArrayOutputStream outputStream;
-    private S3Client s3ResourcesClient;
     private S3Driver s3ResourcesDriver;
-    private S3Client s3BatchesClient;
     private S3Driver s3BatchesDriver;
-    private EventBridgeClient eventBridgeClient;
-    private S3Client s3OutputClient;
     private S3Driver s3OutputDriver;
+    private FakeSqsClient queueClient;
+    private BulkTransformerHandler handler;
 
     @BeforeEach
     void setup() {
         outputStream = new ByteArrayOutputStream();
-        s3ResourcesClient = new FakeS3Client();
+        S3Client s3ResourcesClient = new FakeS3Client();
         s3ResourcesDriver = new S3Driver(s3ResourcesClient, "resources");
-        s3BatchesClient = new FakeS3Client();
+        S3Client s3BatchesClient = new FakeS3Client();
         s3BatchesDriver = new S3Driver(s3BatchesClient, "batchesBucket");
-        s3OutputClient = new FakeS3Client();
+        S3Client s3OutputClient = new FakeS3Client();
         s3OutputDriver = new S3Driver(s3OutputClient, "loaderBucket");
+        queueClient = new FakeSqsClient();
+        handler = new BulkTransformerHandler(s3ResourcesClient, s3BatchesClient, s3OutputClient, queueClient);
+    }
 
-        eventBridgeClient = new StubEventBridgeClient();
+    @AfterEach
+    void tearDown() {
+        queueClient.removeSentMessages();
     }
 
     @Test
@@ -82,10 +80,6 @@ class BulkTransformerHandlerTest {
                         .collect(Collectors.joining(System.lineSeparator()));
         var batchKey = randomString();
         s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
-        var handler = new BulkTransformerHandler(s3ResourcesClient,
-                                                 s3BatchesClient,
-                                                 s3OutputClient,
-                                                 eventBridgeClient);
         handler.handleRequest(eventStream(null), outputStream, mock(Context.class));
         var file = s3OutputDriver.listAllFiles(UnixPath.of("")).getFirst();
         var contentString = s3OutputDriver.getFile(file);
@@ -96,10 +90,6 @@ class BulkTransformerHandlerTest {
     void shouldSkipEmptyBatches() throws IOException {
         var batchKey = randomString();
         s3BatchesDriver.insertFile(UnixPath.of(batchKey), StringUtils.EMPTY_STRING);
-        var handler = new BulkTransformerHandler(s3ResourcesClient,
-                                                 s3BatchesClient,
-                                                 s3OutputClient,
-                                                 eventBridgeClient);
         handler.handleRequest(eventStream(null), outputStream, Mockito.mock(Context.class));
 
         var actual = s3OutputDriver.listAllFiles(UnixPath.of(""));
@@ -114,14 +104,8 @@ class BulkTransformerHandlerTest {
                         .collect(Collectors.joining(System.lineSeparator()));
         var batchKey = randomString();
         s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
-        var handler = new BulkTransformerHandler(s3ResourcesClient,
-                                                 s3BatchesClient,
-                                                 s3OutputClient,
-                                                 eventBridgeClient);
         handler.handleRequest(eventStream(null), outputStream, Mockito.mock(Context.class));
-
-        var emittedEvent = ((StubEventBridgeClient) eventBridgeClient).getLatestEvent();
-        assertNull(emittedEvent);
+        assertEquals(0, queueClient.getSentMessages().size());
     }
 
     @Test
@@ -138,17 +122,12 @@ class BulkTransformerHandlerTest {
         list.add(null);
         list.add(batchKey);
         list.add(expectedStarMarkerFromEmittedEvent);
-        var handler = new BulkTransformerHandler(s3ResourcesClient,
-                                                 s3BatchesClient,
-                                                 s3OutputClient,
-                                                 eventBridgeClient);
         for (var item : list) {
             handler.handleRequest(eventStream(item), outputStream, Mockito.mock(Context.class));
-
-            var emittedEvent = ((StubEventBridgeClient) eventBridgeClient).getLatestEvent();
-
-            assertEquals(batchKey, emittedEvent.getStartMarker());
-            assertEquals(DEFAULT_LOCATION, emittedEvent.getLocation());
+            var sentMessage = dtoObjectMapper.readValue(queueClient.getSentMessages().get(0).messageBody(),
+                                                        KeyBatchRequestEvent.class);
+            assertEquals(batchKey, sentMessage.getStartMarker());
+            assertEquals(DEFAULT_LOCATION, sentMessage.getLocation());
         }
     }
 
@@ -181,10 +160,6 @@ class BulkTransformerHandlerTest {
                         .collect(Collectors.joining(System.lineSeparator()));
         var batchKey = randomString();
         s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
-        var handler = new BulkTransformerHandler(s3ResourcesClient,
-                                                 s3BatchesClient,
-                                                 s3OutputClient,
-                                                 eventBridgeClient);
         Executable executable = () -> handler.handleRequest(eventStream(null),
                                                             outputStream,
                                                             mock(Context.class));
@@ -228,37 +203,5 @@ class BulkTransformerHandlerTest {
         return attempt(
             () -> objectMapperWithEmpty.readTree(
                 VALID_PUBLICATION.replace(IDENTIFIER, randomUUID().toString()))).orElseThrow();
-    }
-
-    private static class StubEventBridgeClient implements EventBridgeClient {
-
-        private KeyBatchRequestEvent latestEvent;
-
-        public KeyBatchRequestEvent getLatestEvent() {
-            return latestEvent;
-        }
-
-        public PutEventsResponse putEvents(PutEventsRequest putEventsRequest) {
-            this.latestEvent = saveContainedEvent(putEventsRequest);
-            return PutEventsResponse.builder().failedEntryCount(0).build();
-        }
-
-        @Override
-        public String serviceName() {
-            return null;
-        }
-
-        @Override
-        public void close() {
-
-        }
-
-        private KeyBatchRequestEvent saveContainedEvent(PutEventsRequest putEventsRequest) {
-            PutEventsRequestEntry eventEntry = putEventsRequest.entries()
-                                                   .stream()
-                                                   .collect(SingletonCollector.collect());
-            return attempt(eventEntry::detail).map(
-                jsonString -> objectMapperWithEmpty.readValue(jsonString, KeyBatchRequestEvent.class)).orElseThrow();
-        }
     }
 }

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/BulkTransformerHandlerTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
-import software.amazon.awssdk.services.s3.S3Client;
 
 class BulkTransformerHandlerTest {
 
@@ -57,11 +56,11 @@ class BulkTransformerHandlerTest {
     @BeforeEach
     void setup() {
         outputStream = new ByteArrayOutputStream();
-        S3Client s3ResourcesClient = new FakeS3Client();
+        var s3ResourcesClient = new FakeS3Client();
         s3ResourcesDriver = new S3Driver(s3ResourcesClient, "resources");
-        S3Client s3BatchesClient = new FakeS3Client();
+        var s3BatchesClient = new FakeS3Client();
         s3BatchesDriver = new S3Driver(s3BatchesClient, "batchesBucket");
-        S3Client s3OutputClient = new FakeS3Client();
+        var s3OutputClient = new FakeS3Client();
         s3OutputDriver = new S3Driver(s3OutputClient, "loaderBucket");
         queueClient = new FakeSqsClient();
         handler = new BulkTransformerHandler(s3ResourcesClient, s3BatchesClient, s3OutputClient, queueClient);
@@ -124,7 +123,7 @@ class BulkTransformerHandlerTest {
         list.add(expectedStarMarkerFromEmittedEvent);
         for (var item : list) {
             handler.handleRequest(eventStream(item), outputStream, Mockito.mock(Context.class));
-            var sentMessage = dtoObjectMapper.readValue(queueClient.getSentMessages().get(0).messageBody(),
+            var sentMessage = dtoObjectMapper.readValue(queueClient.getSentMessages().getFirst().messageBody(),
                                                         KeyBatchRequestEvent.class);
             assertEquals(batchKey, sentMessage.getStartMarker());
             assertEquals(DEFAULT_LOCATION, sentMessage.getLocation());

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/FakeSqsClient.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/FakeSqsClient.java
@@ -1,0 +1,27 @@
+package no.sikt.nva.data.report.api.etl.transformer;
+
+import no.sikt.nva.data.report.api.etl.queue.MessageResponse;
+import no.sikt.nva.data.report.api.etl.queue.QueueClient;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+public class FakeSqsClient implements QueueClient {
+
+    private final List<SendMessageRequest> sentMessages = new ArrayList<>();
+
+    public List<SendMessageRequest> getSentMessages() {
+        return sentMessages;
+    }
+
+    @Override
+    public MessageResponse sendMessage(String body) {
+        var messageRequest = SendMessageRequest.builder().messageBody(body).build();
+        sentMessages.add(messageRequest);
+        return new MessageResponse("fakeMessageId");
+    }
+
+    public void removeSentMessages() {
+        sentMessages.clear();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge',
 aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'awsSdk2' }
 aws-sdk2-sqs = { group = 'software.amazon.awssdk', name = 'sqs', version.ref = 'awsSdk2' }
 aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
+aws-sdk2-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }
 aws-sdk2-lambda-events = { group = 'com.amazonaws', name = 'aws-lambda-java-events', version.ref = 'awsSdk2Events' }
 aws-sdk2-secrets = { group = 'software.amazon.awssdk', name = 'secretsmanager', version.ref = 'awsSdk2' }
 

--- a/template.yaml
+++ b/template.yaml
@@ -90,6 +90,17 @@ Globals:
 Resources:
 
   # ---- SQS ----
+  BulkTransformerQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt BulkTransformerQueueDLQ.Arn
+        maxReceiveCount: 5
+  # ---- DLQs ----
+  BulkTransformerQueueDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 #14 days
   DataReportPersistedResourceDLQ:
     Type: AWS::SQS::Queue
     Properties:
@@ -468,20 +479,21 @@ Resources:
         - !GetAtt DeleteS3ObjectPolicy.PolicyArn
       Environment:
         Variables:
-          EVENT_BUS: !GetAtt BatchLoadEventBus.Name
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
           KEY_BATCHES_BUCKET: !Ref KeyBatchesBucket
           LOADER_BUCKET: !Ref LoaderBucket
-          TOPIC: 'ReportApi.Bulk.TransformKeyBatch'
           API_HOST: !Ref ApiDomain
+          BULK_TRANSFORMER_QUEUE_URL: !Ref BulkTransformerQueue
       Events:
-        BatchIndexEvent:
-          Type: EventBridgeRule
+        SqsEvent:
+          Type: SQS
           Properties:
-            EventBusName: !GetAtt BatchLoadEventBus.Name
-            Pattern:
-              detail:
-                topic: [ 'ReportApi.Bulk.TransformKeyBatch' ]
+            Queue: !GetAtt BulkTransformerQueue.Arn
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt BulkTransformerQueueDLQ.Arn
 
   # ---- Amazon Neptune ----
   # Two instance Amazon Neptune cluster, using default


### PR DESCRIPTION
Bug: NP-46736 BulkTransformer: n-triples are generated twice for all key-batches. Switch from eventbus to sqs-queue