### PR TITLE
BulkTransformerHandler: Process in parallell and timeout config

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -93,6 +93,7 @@ Resources:
   BulkTransformerQueue:
     Type: AWS::SQS::Queue
     Properties:
+      VisibilityTimeout: 300
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt BulkTransformerQueueDLQ.Arn
         maxReceiveCount: 5
@@ -475,6 +476,7 @@ Resources:
     Properties:
       CodeUri: bulk-load
       Handler: no.sikt.nva.data.report.api.etl.transformer.BulkTransformerHandler::handleRequest
+      Timeout: 300
       MemorySize: 1536
       AutoPublishAlias: live
       Policies:


### PR DESCRIPTION
- Send new event before generating and persisting ntriples. We have configured a DLQ and can re-process failed events with a DLQ redrive.
- `BulkTransformerHandler` needs a longer timeout. Setting to 300 sek, and therefore having to adjust visibility timeout for queue `BulkTransformerQueue`