### PR TITLE
BulkLoadHandler, set loader spec failOnError to false

### DIFF
--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/loader/BulkLoadHandler.java
@@ -112,7 +112,7 @@ public class BulkLoadHandler implements RequestStreamHandler {
         return new LoaderSpec.Builder()
                    .withSource(getLoaderSpecSource(environment))
                    .withFormat(Format.NQUADS)
-                   .withFailOnError(true)
+                   .withFailOnError(false)
                    .withParallelism(Parallelism.MEDIUM)
                    .withIamRoleArn(environment.readEnv(LOADER_IAM_ROLE))
                    .withQueueRequest(true)


### PR DESCRIPTION
Argument: Lets us debug, resolve and retry loading _only_ for failed files