### PR TITLE
Update nvi model with involvedOrganizations

### DIFF
--- a/report-api/src/main/resources/template/nvi-institution-status.sparql
+++ b/report-api/src/main/resources/template/nvi-institution-status.sparql
@@ -2,7 +2,6 @@ PREFIX : <https://nva.sikt.no/ontology/publication#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-
 SELECT DISTINCT
   ?ARSTALL
   ?VARBEIDLOPENR
@@ -17,33 +16,23 @@ SELECT DISTINCT
   ?AVDNR
   ?UNDAVDNR
   ?GRUPPENR
-  ?FORFATTERE_TOTALT
-  ?FORFATTERE_INT
-  ?VEKTET
   ?ETTERNAVN
   ?FORNAVN
   ?PUBLISERINGSKANALNAVN
-  ?SIDE_FRA
-  ?SIDE_TIL
-  ?SIDEANTALL
   ?VA_TITTEL
-  ?SPRAK
   ?RAPPORTSTATUS
   ?VEKTINGSTALL
   ?FAKTORTALL_SAMARBEID
-  ?FORFATTERDEL
   ?FORFATTERVEKT
   WHERE {
    GRAPH ?nvi {
        ?candidate a :NviCandidate ;
                :publicationDetails ?publicationUri ;
-               :isApplicable ?isApplicable ;
+               :isApplicable true ;
                :internationalCollaborationFactor ?internationalCollaborationFactor ;
                :globalApprovalStatus ?globalApprovalStatus ;
                :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints ;
                :reportingPeriod ?reportingPeriod .
-
-       FILTER (?isApplicable = true)
 
        ?reportingPeriod a :ReportingPeriod ;
                         :year ?reportingYear .
@@ -71,14 +60,15 @@ SELECT DISTINCT
        ?contributorId :affiliation ?affiliationUri .
              ?affiliationUri a ?NviOrganization .
 
+      BIND(URI("__REPLACE_WITH_TOP_LEVEL_ORGANIZATION__") AS ?organizationUri)
+      BIND(STR(?affiliationUri) AS ?affiliationUriString)
+
        ?candidate :approval ?approval .
        ?approval a :Approval ;
          :approvalStatus ?approvalStatus ;
          :points ?institutionPoints ;
-         :institutionId ?organizationUri .
-
-       FILTER (?affiliationUri = ?organizationUri || EXISTS { ?affiliationUri :partOf ?organizationUri . })
-       FILTER (STR(?organizationUri) = "__REPLACE_WITH_TOP_LEVEL_ORGANIZATION__")
+         :institutionId ?organizationUri ;
+         :involvedOrganization ?affiliationUriString .
 
        ?institutionPoints a :InstitutionPoints ;
          :creatorAffiliationPoints ?creatorAffiliationPoints .
@@ -102,15 +92,6 @@ SELECT DISTINCT
        BIND(STRBEFORE(str(?temp1), ".") AS ?AVDNR)
        BIND(STRBEFORE(str(?temp2), ".") AS ?UNDAVDNR)
 
-       #These are todos
-       BIND("FORFATTERE_TOTALT" AS ?FORFATTERE_TOTALT)
-       BIND("FORFATTERE_INT" AS ?FORFATTERE_INT)
-       BIND("SIDE_FRA" AS ?SIDE_FRA)
-       BIND("SIDE_TIL" AS ?SIDE_TIL)
-       BIND("SIDEANTALL" AS ?SIDEANTALL)
-       BIND("SPRAK" AS ?SPRAK)
-       BIND("FORFATTERDEL" AS ?FORFATTERDEL)
-       BIND("FORFATTERVEKT" AS ?VEKTET)
      }
      GRAPH ?nva {
         ?publicationUri a :Publication ;
@@ -151,5 +132,3 @@ SELECT DISTINCT
         BIND(?contributorName AS ?FORNAVN)
      }
     } LIMIT __PAGE_SIZE__ OFFSET __OFFSET__
-
-

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusHeaders.java
@@ -5,7 +5,7 @@ public final class NviInstitutionStatusHeaders {
     public static String PUBLICATION_IDENTIFIER = "VARBEIDLOPENR";
     public static String REPORTING_YEAR = "ARSTALL";
     public static String PUBLISHED_YEAR = "ARSTALL_REG";
-    public static String INSTITUTION_APPROVAL_STATUS = "STATUS_KONTROLLERT";//TODO: Check if this is correct
+    public static String INSTITUTION_APPROVAL_STATUS = "STATUS_KONTROLLERT";
     public static String PUBLICATION_INSTANCE = "PUBLIKASJONSFORM";
     public static String PUBLICATION_CHANNEL_TYPE = "PUBLISERINGSKANALTYPE";
     public static String ISSN = "ISSN";
@@ -15,20 +15,12 @@ public final class NviInstitutionStatusHeaders {
     public static final String FACULTY_ID = "AVDNR";
     public static final String DEPARTMENT_ID = "UNDAVDNR";
     public static final String GROUP_ID = "GRUPPENR";
-    public static final String AUTHOR_COUNT = "FORFATTERE_TOTALT";
-    public static final String AUTHOR_INT = "FORFATTERE_INT";//TODO: Find out what this is
-    public static final String PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS = "VEKTET"; //TODO: Check if this is correct
     public static final String LAST_NAME = "ETTERNAVN";
     public static final String FIRST_NAME = "FORNAVN";
     public static final String PUBLICATION_CHANNEL_NAME = "PUBLISERINGSKANALNAVN";
-    public static final String PAGE_FROM = "SIDE_FRA";
-    public static final String PAGE_TO = "SIDE_TIL";
-    public static final String PAGE_COUNT = "SIDEANTALL";
     public static final String PUBLICATION_TITLE = "VA_TITTEL";
-    public static final String LANGUAGE = "SPRAK";
     public static final String GLOBAL_STATUS = "RAPPORTSTATUS";
-    public static final String TOTAL_POINTS = "VEKTINGSTALL"; //TODO: Check if this is correct
+    public static final String PUBLICATION_CHANNEL_LEVEL_POINTS = "VEKTINGSTALL";
     public static final String INTERNATIONAL_COLLABORATION_FACTOR = "FAKTORTALL_SAMARBEID";
-    public static final String AUTHOR_SHARE_COUNT = "FORFATTERDEL";
     public static final String POINTS_FOR_AFFILIATION = "FORFATTERVEKT";
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviInstitutionStatusTestData.java
@@ -1,8 +1,5 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator;
 
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.AUTHOR_COUNT;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.AUTHOR_INT;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.AUTHOR_SHARE_COUNT;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.CONTRIBUTOR_IDENTIFIER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.DEPARTMENT_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.FACULTY_ID;
@@ -13,22 +10,17 @@ import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstituti
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INSTITUTION_ID;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.INTERNATIONAL_COLLABORATION_FACTOR;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.ISSN;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LANGUAGE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.LAST_NAME;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PAGE_COUNT;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PAGE_FROM;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PAGE_TO;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.POINTS_FOR_AFFILIATION;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_CHANNEL_LEVEL;
+import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_CHANNEL_LEVEL_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_CHANNEL_NAME;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_CHANNEL_TYPE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_IDENTIFIER;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_INSTANCE;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_TITLE;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.PUBLISHED_YEAR;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.REPORTING_YEAR;
-import static no.sikt.nva.data.report.api.fetch.testutils.generator.NviInstitutionStatusHeaders.TOTAL_POINTS;
 import static no.sikt.nva.data.report.api.fetch.testutils.generator.publication.TestPublication.DELIMITER;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.util.List;
@@ -60,21 +52,13 @@ public final class NviInstitutionStatusTestData {
                                                                               FACULTY_ID,
                                                                               DEPARTMENT_ID,
                                                                               GROUP_ID,
-                                                                              AUTHOR_COUNT,
-                                                                              AUTHOR_INT,
-                                                                              PUBLICATION_TYPE_CHANNEL_LEVEL_POINTS,
                                                                               LAST_NAME,
                                                                               FIRST_NAME,
                                                                               PUBLICATION_CHANNEL_NAME,
-                                                                              PAGE_FROM,
-                                                                              PAGE_TO,
-                                                                              PAGE_COUNT,
                                                                               PUBLICATION_TITLE,
-                                                                              LANGUAGE,
                                                                               GLOBAL_STATUS,
-                                                                              TOTAL_POINTS,
+                                                                              PUBLICATION_CHANNEL_LEVEL_POINTS,
                                                                               INTERNATIONAL_COLLABORATION_FACTOR,
-                                                                              AUTHOR_SHARE_COUNT,
                                                                               POINTS_FOR_AFFILIATION);
 
     public static String generateExpectedNviInstitutionResponse(TestNviContributor contributor,
@@ -108,21 +92,13 @@ public final class NviInstitutionStatusTestData {
             .append(affiliation.getSubUnitOneNumber()).append(DELIMITER)
             .append(affiliation.getSubUnitTwoNumber()).append(DELIMITER)
             .append(affiliation.getSubUnitThreeNumber()).append(DELIMITER)
-            .append(AUTHOR_COUNT).append(DELIMITER)//TODO: Implement
-            .append(AUTHOR_INT).append(DELIMITER)//TODO: Implement
-            .append(POINTS_FOR_AFFILIATION).append(DELIMITER) //TODO: Implement
             .append(identity.name()).append(DELIMITER)
             .append(identity.name()).append(DELIMITER)
             .append(publication.getChannel().getName()).append(DELIMITER)
-            .append(PAGE_FROM).append(DELIMITER)//TODO: Implement
-            .append(PAGE_TO).append(DELIMITER)//TODO: Implement
-            .append(PAGE_COUNT).append(DELIMITER)//TODO: Implement
             .append(publication.getMainTitle()).append(DELIMITER)
-            .append(LANGUAGE).append(DELIMITER)//TODO: Implement
             .append(getExpectedApprovalStatusValue(candidate.globalApprovalStatus())).append(DELIMITER)
             .append(candidate.publicationTypeChannelLevelPoints()).append(DELIMITER)
             .append(candidate.internationalCollaborationFactor()).append(DELIMITER)
-            .append(AUTHOR_SHARE_COUNT).append(DELIMITER)//TODO: Implement
             .append(NviTestUtils.getExpectedPointsForAffiliation(affiliation, contributor, approval))
             .append(CRLF.getString());
     }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/NviTestData.java
@@ -26,8 +26,10 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApproval;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestApprovalStatus;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.nvi.TestCreatorAffiliationPoints;
@@ -188,11 +190,22 @@ public final class NviTestData {
     private static TestApproval generateApproval(String topLevelOrganization,
                                                  TestPublicationDetails publicationDetails) {
         var nviContributors = publicationDetails.filterContributorsWithTopLevelOrg(topLevelOrganization);
+        var involvedOrgs = getAffiliations(topLevelOrganization, nviContributors);
+        involvedOrgs.add(topLevelOrganization);
         return TestApproval.builder()
                    .withInstitutionId(URI.create(topLevelOrganization))
                    .withApprovalStatus(randomElement(TestApprovalStatus.values()))
                    .withPoints(generateInstitutionPoints(topLevelOrganization, nviContributors))
+                   .withInvolvedOrganizations(involvedOrgs)
                    .build();
+    }
+
+    private static HashSet<String> getAffiliations(String topLevelOrganization,
+                                                   List<TestNviContributor> nviContributors) {
+        return nviContributors.stream()
+                   .flatMap(contributor -> contributor.filterAffiliationsWithTopLevelOrg(topLevelOrganization).stream())
+                   .map(TestNviOrganization::id)
+                   .collect(Collectors.toCollection(HashSet::new));
     }
 
     private static TestInstitutionPoints generateInstitutionPoints(String topLevelOrganization,

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
+import java.util.Set;
 import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
@@ -15,6 +16,8 @@ public class ApprovalGenerator extends TripleBasedBuilder {
     public static final PropertyImpl POINTS_PROPERTY = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "points");
     public static final PropertyImpl APPROVAL_STATUS = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "approvalStatus");
     public static final PropertyImpl INSTITUTION_ID = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "institutionId");
+    public static final Property INVOLVED_ORGANIZATION = new PropertyImpl(Constants.ONTOLOGY_BASE_URI,
+                                                                          "involvedOrganization");
     private static final Property APPROVAL = new PropertyImpl(Constants.ONTOLOGY_BASE_URI, "Approval");
     private final Model model;
     private final Resource subject;
@@ -38,6 +41,11 @@ public class ApprovalGenerator extends TripleBasedBuilder {
     public ApprovalGenerator withPoints(InstitutionPointsGenerator institutionPointsGenerator) {
         model.add(subject, POINTS_PROPERTY, institutionPointsGenerator.getSubject());
         model.add(institutionPointsGenerator.build());
+        return this;
+    }
+
+    public ApprovalGenerator withInvolvedOrganizations(Set<String> involvedOrganizations) {
+        involvedOrganizations.forEach(organization -> model.add(subject, INVOLVED_ORGANIZATION, organization));
         return this;
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestApproval.java
@@ -1,11 +1,12 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.nvi;
 
-import java.math.BigDecimal;
 import java.net.URI;
+import java.util.Set;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi.ApprovalGenerator;
 
 public record TestApproval(URI institutionId,
                            TestApprovalStatus approvalStatus,
+                           Set<String> involvedOrganizations,
                            TestInstitutionPoints points) {
 
     public static Builder builder() {
@@ -20,6 +21,7 @@ public record TestApproval(URI institutionId,
 
         private URI institutionId;
         private TestApprovalStatus approvalStatus;
+        private Set<String> involvedOrganizations;
         private TestInstitutionPoints points;
 
         private Builder() {
@@ -35,13 +37,18 @@ public record TestApproval(URI institutionId,
             return this;
         }
 
+        public Builder withInvolvedOrganizations(Set<String> involvedOrganizations) {
+            this.involvedOrganizations = involvedOrganizations;
+            return this;
+        }
+
         public Builder withPoints(TestInstitutionPoints points) {
             this.points = points;
             return this;
         }
 
         public TestApproval build() {
-            return new TestApproval(institutionId, approvalStatus, points);
+            return new TestApproval(institutionId, approvalStatus, involvedOrganizations, points);
         }
     }
 }

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/nvi/TestNviCandidate.java
@@ -60,7 +60,8 @@ public record TestNviCandidate(String identifier,
         return new ApprovalGenerator()
                    .withApprovalStatus(testApproval.approvalStatus().getValue())
                    .withInstitutionId(new OrganizationGenerator(testApproval.institutionId().toString()))
-                   .withPoints(institutionPointsGenerator);
+                   .withPoints(institutionPointsGenerator)
+                   .withInvolvedOrganizations(testApproval.involvedOrganizations());
     }
 
     private void generateExpectedLinesForNonApplicableCandidate(StringBuilder stringBuilder) {


### PR DESCRIPTION
- Removed headers that are not in use and not implemented
- Replaced `partOf`-filter with `involvedOrganization`-select to reduce complexity and query time

Next PR: Move data manipulation/transformation from sparql query to java code