### PR TITLE
Create valid blank nodes uniformly

### DIFF
--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/ApprovalGenerator.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
 import java.util.Set;
-import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.publication.OrganizationGenerator;
@@ -24,7 +23,7 @@ public class ApprovalGenerator extends TripleBasedBuilder {
 
     public ApprovalGenerator() {
         this.model = ModelFactory.createDefaultModel();
-        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
+        this.subject = BlankNodeUtil.createRandom(model);
         model.add(subject, TYPE, APPROVAL);
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/BlankNodeUtil.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/BlankNodeUtil.java
@@ -1,0 +1,16 @@
+package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
+
+import java.util.UUID;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+
+public class BlankNodeUtil {
+
+    public static final String BLANK_NODE_PREFIX = "_:";
+    public static final String HYPHEN = "-";
+    public static final String EMPTY_STRING = "";
+
+    public static Resource createRandom(Model model) {
+        return model.createResource(BLANK_NODE_PREFIX + UUID.randomUUID().toString().replace(HYPHEN, EMPTY_STRING));
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CreatorAffiliationPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/CreatorAffiliationPointsGenerator.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
 import org.apache.jena.datatypes.xsd.impl.XSDDouble;
@@ -23,7 +22,7 @@ public class CreatorAffiliationPointsGenerator extends TripleBasedBuilder {
 
     public CreatorAffiliationPointsGenerator() {
         this.model = ModelFactory.createDefaultModel();
-        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
+        this.subject = BlankNodeUtil.createRandom(model);
         model.add(subject, TYPE, CREATOR_AFFILIATION_POINTS);
     }
 

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/testutils/generator/model/nvi/InstitutionPointsGenerator.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.data.report.api.fetch.testutils.generator.model.nvi;
 
-import java.util.UUID;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.Constants;
 import no.sikt.nva.data.report.api.fetch.testutils.generator.model.TripleBasedBuilder;
 import org.apache.jena.rdf.model.Model;
@@ -20,7 +19,7 @@ public class InstitutionPointsGenerator extends TripleBasedBuilder {
 
     public InstitutionPointsGenerator() {
         this.model = ModelFactory.createDefaultModel();
-        this.subject = model.createResource("someBlankNode" + UUID.randomUUID());
+        this.subject = BlankNodeUtil.createRandom(model);
         model.add(subject, TYPE, INSTITUTION_POINTS);
     }
 


### PR DESCRIPTION
Previously, we weren't creating valid blank nodes, not causing any failure, but the triples we created were ignored and created a lot of noisy log messages when building.