### PR TITLE
Np 46747 BulkReportGenerator, input validation

### DIFF
--- a/report-api/build.gradle
+++ b/report-api/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation libs.nva.json
     implementation libs.nva.commons.auth
     implementation libs.nva.commons.secrets
+    implementation libs.nva.eventhandlers
     implementation libs.nva.s3
     implementation libs.aws.sdk2.secrets
     implementation libs.bundles.jena

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
@@ -2,23 +2,25 @@ package no.sikt.nva.data.report.api.fetch;
 
 import static java.util.Objects.isNull;
 import com.amazonaws.services.lambda.runtime.Context;
+import no.sikt.nva.data.report.api.fetch.model.ReportType;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 
-public class BulkReportGenerator extends EventHandler<GenerateReportRequest, Void> {
+public class BulkReportGenerator extends EventHandler<BulkReportRequest, Void> {
 
     protected BulkReportGenerator() {
-        super(GenerateReportRequest.class);
+        super(BulkReportRequest.class);
     }
 
     @Override
-    protected Void processInput(GenerateReportRequest request, AwsEventBridgeEvent<GenerateReportRequest> event,
+    protected Void processInput(BulkReportRequest request, AwsEventBridgeEvent<BulkReportRequest> event,
                                 Context context) {
         validate(request);
+        ReportType.parse(request.reportType());
         return null;
     }
 
-    private static void validate(GenerateReportRequest request) {
+    private static void validate(BulkReportRequest request) {
         if (isNull(request.reportType())) {
             throw new IllegalArgumentException("Report type is required");
         }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
@@ -5,8 +5,12 @@ import com.amazonaws.services.lambda.runtime.Context;
 import no.sikt.nva.data.report.api.fetch.model.ReportType;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BulkReportGenerator extends EventHandler<BulkReportRequest, Void> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BulkReportGenerator.class);
 
     protected BulkReportGenerator() {
         super(BulkReportRequest.class);
@@ -16,7 +20,8 @@ public class BulkReportGenerator extends EventHandler<BulkReportRequest, Void> {
     protected Void processInput(BulkReportRequest request, AwsEventBridgeEvent<BulkReportRequest> event,
                                 Context context) {
         validate(request);
-        ReportType.parse(request.reportType());
+        var reportType = ReportType.parse(request.reportType());
+        logger.info("Report type: {}", reportType.getType());
         return null;
     }
 

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
@@ -1,0 +1,18 @@
+package no.sikt.nva.data.report.api.fetch;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+
+public class BulkReportGenerator extends EventHandler<GenerateReportRequest, Void> {
+
+    protected BulkReportGenerator() {
+        super(GenerateReportRequest.class);
+    }
+
+    @Override
+    protected Void processInput(GenerateReportRequest generateReportRequest,
+                                AwsEventBridgeEvent<GenerateReportRequest> awsEventBridgeEvent, Context context) {
+        return null;
+    }
+}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.data.report.api.fetch;
 
+import static java.util.Objects.isNull;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
@@ -11,8 +12,15 @@ public class BulkReportGenerator extends EventHandler<GenerateReportRequest, Voi
     }
 
     @Override
-    protected Void processInput(GenerateReportRequest generateReportRequest,
-                                AwsEventBridgeEvent<GenerateReportRequest> awsEventBridgeEvent, Context context) {
+    protected Void processInput(GenerateReportRequest request, AwsEventBridgeEvent<GenerateReportRequest> event,
+                                Context context) {
+        validate(request);
         return null;
+    }
+
+    private static void validate(GenerateReportRequest request) {
+        if (isNull(request.reportType())) {
+            throw new IllegalArgumentException("Report type is required");
+        }
     }
 }

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportRequest.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/BulkReportRequest.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.data.report.api.fetch;
+
+public record BulkReportRequest(String reportType) {
+
+}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/GenerateReportRequest.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/GenerateReportRequest.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.data.report.api.fetch;
+
+public record GenerateReportRequest(String reportType) {
+
+}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/GenerateReportRequest.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/GenerateReportRequest.java
@@ -1,5 +1,0 @@
-package no.sikt.nva.data.report.api.fetch;
-
-public record GenerateReportRequest(String reportType) {
-
-}

--- a/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/model/ReportType.java
+++ b/report-api/src/main/java/no/sikt/nva/data/report/api/fetch/model/ReportType.java
@@ -2,7 +2,6 @@ package no.sikt.nva.data.report.api.fetch.model;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import nva.commons.apigateway.exceptions.BadRequestException;
 
 public enum ReportType {
     AFFILIATION("affiliation"),
@@ -13,27 +12,27 @@ public enum ReportType {
     NVI("nvi");
 
     public static final String DELIMITER = ", ";
-    public static final String BAD_REQUEST_MESSAGE_TEMPLATE = "Bad request. Acceptable report types: %s";
+    public static final String BAD_REQUEST_MESSAGE_TEMPLATE = "Illegal argument. Acceptable report types: %s";
     private final String type;
 
     ReportType(String type) {
         this.type = type;
     }
 
-    public static ReportType parse(String candidate) throws BadRequestException {
+    public static ReportType parse(String candidate) throws IllegalArgumentException {
         return Arrays.stream(values())
                    .filter(reportType -> reportType.getType().equals(candidate))
                    .findAny()
-                   .orElseThrow(ReportType::getBadRequest);
+                   .orElseThrow(ReportType::getIllegalArgument);
     }
 
     public String getType() {
         return type;
     }
 
-    private static BadRequestException getBadRequest() {
+    private static IllegalArgumentException getIllegalArgument() {
         var message = String.format(BAD_REQUEST_MESSAGE_TEMPLATE, getValidReportTypes());
-        return new BadRequestException(message);
+        return new IllegalArgumentException(message);
     }
 
     private static String getValidReportTypes() {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
@@ -1,15 +1,20 @@
 package no.sikt.nva.data.report.api.fetch;
 
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import no.sikt.nva.data.report.api.fetch.model.ReportType;
+import no.sikt.nva.data.report.api.fetch.testutils.NviTestUtils;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,18 +46,12 @@ class BulkReportGeneratorTest {
     }
 
     @Test
-    void shouldProduceReportAndPersistInS3() {
-
-    }
-
-    @Test
-    void shouldNotNewEventWhenThereAreNoMoreItemsToFetch() {
-
-    }
-
-    @Test
-    void shouldEmitNewEventWhenThereAreMoreItemsToFetch() {
-
+    void shouldLogReportType() throws JsonProcessingException {
+        var reportType = randomElement(ReportType.values()).getType();
+        var request = new BulkReportRequest(reportType);
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        handler.handleRequest(eventStream(request), outputStream, context);
+        assertTrue(appender.getMessages().contains(reportType));
     }
 
     private InputStream eventStream(BulkReportRequest detail) throws JsonProcessingException {

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
@@ -28,14 +28,14 @@ class BulkReportGeneratorTest {
 
     @Test
     void shouldRequireReportType() {
-        var request = new GenerateReportRequest(null);
+        var request = new BulkReportRequest(null);
         assertThrows(IllegalArgumentException.class,
                      () -> handler.handleRequest(eventStream(request), outputStream, context));
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenReportTypeIsInvalid() {
-        var request = new GenerateReportRequest(randomString());
+        var request = new BulkReportRequest(randomString());
         assertThrows(IllegalArgumentException.class,
                      () -> handler.handleRequest(eventStream(request), outputStream, context));
     }
@@ -55,8 +55,8 @@ class BulkReportGeneratorTest {
 
     }
 
-    private InputStream eventStream(GenerateReportRequest detail) throws JsonProcessingException {
-        var event = new AwsEventBridgeEvent<GenerateReportRequest>();
+    private InputStream eventStream(BulkReportRequest detail) throws JsonProcessingException {
+        var event = new AwsEventBridgeEvent<BulkReportRequest>();
         event.setDetail(detail);
         event.setId(randomString());
         var jsonString = dtoObjectMapper.writeValueAsString(event);

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
@@ -1,0 +1,58 @@
+package no.sikt.nva.data.report.api.fetch;
+
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.ioutils.IoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BulkReportGeneratorTest {
+
+    private Context context;
+    private ByteArrayOutputStream outputStream;
+    private BulkReportGenerator handler;
+
+    @BeforeEach
+    void setUp() {
+        context = new FakeContext();
+        outputStream = new ByteArrayOutputStream();
+        handler = new BulkReportGenerator();
+    }
+
+    @Test
+    void shouldRequireReportType() {
+        var request = new GenerateReportRequest(null);
+        assertThrows(IllegalArgumentException.class,
+                     () -> handler.handleRequest(eventStream(request), outputStream, context));
+    }
+
+    @Test
+    void shouldProduceReportAndPersistInS3() {
+
+    }
+
+    @Test
+    void shouldNotNewEventWhenThereAreNoMoreItemsToFetch() {
+
+    }
+
+    @Test
+    void shouldEmitNewEventWhenThereAreMoreItemsToFetch() {
+
+    }
+
+    private InputStream eventStream(GenerateReportRequest detail) throws JsonProcessingException {
+        var event = new AwsEventBridgeEvent<GenerateReportRequest>();
+        event.setDetail(detail);
+        event.setId(randomString());
+        var jsonString = dtoObjectMapper.writeValueAsString(event);
+        return IoUtils.stringToStream(jsonString);
+    }
+}

--- a/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
+++ b/report-api/src/test/java/no/sikt/nva/data/report/api/fetch/BulkReportGeneratorTest.java
@@ -34,6 +34,13 @@ class BulkReportGeneratorTest {
     }
 
     @Test
+    void shouldThrowIllegalArgumentExceptionWhenReportTypeIsInvalid() {
+        var request = new GenerateReportRequest(randomString());
+        assertThrows(IllegalArgumentException.class,
+                     () -> handler.handleRequest(eventStream(request), outputStream, context));
+    }
+
+    @Test
     void shouldProduceReportAndPersistInS3() {
 
     }


### PR DESCRIPTION
Jira task: Np 46747 Database-dumps for initial import

- New handler `BulkReportGenerator`
- Requires report type as input

Next steps:
- For requested report type, paginate throw database and aggregate results in one file in s3 bucket
- Process and persist in batches. One page result = one invocation, trigger new invocation if there are more paegs to scan

Not sure about the name `BulkReportGenerator`, feel free to suggest something else.