### PR TITLE
Np 47307 CsvTransformer, create files for nvi data

### DIFF
--- a/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/CsvTransformer.java
+++ b/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/CsvTransformer.java
@@ -65,7 +65,7 @@ public class CsvTransformer extends BulkTransformerHandler {
             return List.of(transform(model, ReportType.NVI));
         } else {
             throw new IllegalArgumentException(
-                "Unknown batch location provided. Valid key batch locations are 'resources' and 'nvi-candidates'");
+                "Unknown key batch location provided. Valid key batch locations are 'resources' and 'nvi-candidates'");
         }
     }
 

--- a/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/DocumentType.java
+++ b/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/DocumentType.java
@@ -1,0 +1,31 @@
+package no.sikt.nva.data.report.api.export;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public enum DocumentType {
+    PUBLICATION("resources"),
+    NVI_CANDIDATE("nvi-candidates");
+
+    private final String keyPrefix;
+
+    DocumentType(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
+    }
+
+    public static DocumentType fromLocation(String location) {
+        return Stream.of(values())
+                   .filter(type -> type.getKeyPrefix().equalsIgnoreCase(location))
+                   .findFirst()
+                   .orElseThrow(DocumentType::getIllegalArgument);
+    }
+
+    public String getKeyPrefix() {
+        return keyPrefix;
+    }
+
+    private static IllegalArgumentException getIllegalArgument() {
+        var message = String.format("Illegal argument. Acceptable locations are: %s", Arrays.toString(values()));
+        return new IllegalArgumentException(message);
+    }
+}

--- a/bulk-export/src/main/resources/template/nvi.sparql
+++ b/bulk-export/src/main/resources/template/nvi.sparql
@@ -1,0 +1,87 @@
+PREFIX : <https://nva.sikt.no/ontology/publication#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT DISTINCT
+  ?publicationId
+  ?contributorIdentifier
+  ?affiliationId
+  ?institutionId
+  ?institutionPoints
+  ?pointsForAffiliation
+  ?institutionApprovalStatus
+  ?globalApprovalStatus
+  ?reportedPeriod
+  ?totalPoints
+  ?publicationTypeChannelLevelPoints
+  ?authorShareCount
+  ?internationalCollaborationFactor
+  ?isApplicable
+WHERE {
+    {
+      ?candidate a :NviCandidate ;
+        :modifiedDate ?modifiedDate ;
+        :publicationDetails ?publicationUri ;
+        :isApplicable ?isApplicableBoolean ;
+        :points ?totalPoints ;
+        :globalApprovalStatus ?globalApprovalStatus ;
+        :internationalCollaborationFactor ?internationalCollaborationFactorDecimal ;
+        :creatorShareCount ?authorShareCount ;
+        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPointsDecimal .
+
+      BIND(STR(?internationalCollaborationFactorDecimal) AS ?internationalCollaborationFactor) .
+      BIND(STR(?publicationTypeChannelLevelPointsDecimal) AS ?publicationTypeChannelLevelPoints) .
+
+      OPTIONAL {
+        ?candidate :reported ?reported ;
+                   :reportingPeriod ?reportingPeriod .
+        ?reportingPeriod a :ReportingPeriod ;
+                         :year ?reportedYear .
+        BIND(IF(?reported = true, ?reportedYear, "NotReported") AS ?reportedPeriod)
+      }
+
+      BIND(STR(?publicationUri) AS ?publicationId)
+      BIND(STR(?isApplicableBoolean) AS ?isApplicable)
+
+      ?publicationUri :contributor ?contributorId .
+      ?contributorId a :NviContributor .
+      BIND(STR(?contributorId) AS ?contributorIdString)
+      BIND(REPLACE(STR(?contributorId), "^.*/([^/]*)$", "$1") AS ?contributorIdentifier)
+
+      ?contributorId :affiliation ?affiliationUri .
+      ?affiliationUri a ?NviOrganization .
+      BIND(STR(?affiliationUri) AS ?affiliationId)
+
+      ?candidate :approval ?approval .
+      ?approval a :Approval ;
+        :approvalStatus ?institutionApprovalStatus ;
+        :points ?institutionPointsNode ;
+        :institutionId ?organizationUri ;
+        :involvedOrganization ?affiliationId .
+
+      BIND(STR(?organizationUri) AS ?institutionId)
+
+      ?institutionPointsNode a :InstitutionPoints ;
+        :institutionPoints ?institutionPointsDouble ;
+        :creatorAffiliationPoints ?creatorAffiliationPoints .
+
+      ?creatorAffiliationPoints a :CreatorAffiliationPoints ;
+        :nviCreator ?contributorIdString ;
+        :affiliationId ?affiliationId ;
+        :points ?pointsForAffiliationDouble .
+
+      BIND(STR(?pointsForAffiliationDouble) AS ?pointsForAffiliation)
+      BIND(STR(?institutionPointsDouble) AS ?institutionPoints)
+    }
+    UNION
+    {
+      ?candidate a :NviCandidate ;
+        :modifiedDate ?modifiedDate ;
+        :publicationDetails ?publicationUri ;
+        :isApplicable ?isApplicableBoolean .
+
+      BIND(STR(?publicationUri) AS ?publicationId)
+      BIND(STR(?isApplicableBoolean) AS ?isApplicable)
+
+      FILTER(?isApplicableBoolean = false)
+
+    }
+}

--- a/bulk-export/src/main/resources/template/nvi.sparql
+++ b/bulk-export/src/main/resources/template/nvi.sparql
@@ -23,12 +23,9 @@ WHERE {
         :isApplicable ?isApplicableBoolean ;
         :points ?totalPoints ;
         :globalApprovalStatus ?globalApprovalStatus ;
-        :internationalCollaborationFactor ?internationalCollaborationFactorDecimal ;
+        :internationalCollaborationFactor ?internationalCollaborationFactor ;
         :creatorShareCount ?authorShareCount ;
-        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPointsDecimal .
-
-      BIND(STR(?internationalCollaborationFactorDecimal) AS ?internationalCollaborationFactor) .
-      BIND(STR(?publicationTypeChannelLevelPointsDecimal) AS ?publicationTypeChannelLevelPoints) .
+        :publicationTypeChannelLevelPoints ?publicationTypeChannelLevelPoints .
 
       OPTIONAL {
         ?candidate :reported ?reported ;
@@ -60,16 +57,13 @@ WHERE {
       BIND(STR(?organizationUri) AS ?institutionId)
 
       ?institutionPointsNode a :InstitutionPoints ;
-        :institutionPoints ?institutionPointsDouble ;
+        :institutionPoints ?institutionPoints ;
         :creatorAffiliationPoints ?creatorAffiliationPoints .
 
       ?creatorAffiliationPoints a :CreatorAffiliationPoints ;
         :nviCreator ?contributorIdString ;
         :affiliationId ?affiliationId ;
-        :points ?pointsForAffiliationDouble .
-
-      BIND(STR(?pointsForAffiliationDouble) AS ?pointsForAffiliation)
-      BIND(STR(?institutionPointsDouble) AS ?institutionPoints)
+        :points ?pointsForAffiliation .
     }
     UNION
     {

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
@@ -135,8 +135,9 @@ class CsvTransformerTest {
     @Test
     void shouldWriteFilesWithCsvFileExtension() throws IOException {
         var batch = setupExistingBatch(new TestData(generateDatePairs(1)), ReportType.PUBLICATION);
-        s3KeyBatches3Driver.insertFile(UnixPath.of(randomString()), batch);
-        handler.handleRequest(eventStream(null), outputStream, mock(Context.class));
+        var location = PERSISTED_RESOURCES_PUBLICATIONS;
+        s3KeyBatches3Driver.insertFile(UnixPath.of(location).addChild(randomString()), batch);
+        handler.handleRequest(eventStream(null, location), outputStream, mock(Context.class));
         var file = s3OutputDriver.listAllFiles(UnixPath.ROOT_PATH).getFirst();
         assertTrue(file.getLastPathElement().contains(".csv"));
     }
@@ -144,10 +145,11 @@ class CsvTransformerTest {
     @Test
     void shouldWriteFilesWithContentTypeAndEncoding() throws IOException {
         var batch = setupExistingBatch(new TestData(generateDatePairs(1)), ReportType.PUBLICATION);
-        s3KeyBatches3Driver.insertFile(UnixPath.of(randomString()), batch);
+        var location = PERSISTED_RESOURCES_PUBLICATIONS;
+        s3KeyBatches3Driver.insertFile(UnixPath.of(location).addChild(randomString()), batch);
         var mockedS3OutputClient = mock(S3Client.class);
         var handler = new CsvTransformer(s3keyBatchClient, s3ResourcesClient, mockedS3OutputClient, eventBridgeClient);
-        handler.handleRequest(eventStream(null), outputStream, mock(Context.class));
+        handler.handleRequest(eventStream(null, location), outputStream, mock(Context.class));
         var requestWithExpectedContentType = PutObjectRequest.builder()
                                                  .contentType("text/csv; charset=UTF-8")
                                                  .contentEncoding("UTF-8")
@@ -161,8 +163,9 @@ class CsvTransformerTest {
         var testData = new TestData(generateDatePairs(1));
         var batch = setupExistingBatch(testData, ReportType.PUBLICATION);
         var reportType = ReportType.PUBLICATION;
-        s3KeyBatches3Driver.insertFile(UnixPath.of(randomString()), batch);
-        handler.handleRequest(eventStream(null), outputStream, mock(Context.class));
+        var location = PERSISTED_RESOURCES_PUBLICATIONS;
+        s3KeyBatches3Driver.insertFile(UnixPath.of(location).addChild(randomString()), batch);
+        handler.handleRequest(eventStream(null, location), outputStream, mock(Context.class));
         var expectedEncoding = StandardCharsets.UTF_8;
         var actualContent = s3OutputDriver.getUncompressedFile(getFirstFilePath(reportType), expectedEncoding);
         var expectedContent = getExpectedResponseData(reportType, testData);

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
@@ -1,230 +1,23 @@
 package no.sikt.nva.data.report.api.export;
 
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.TestApproval;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestCreatorAffiliationPoints;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestInstitutionPoints;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviCandidate;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviContributor;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviOrganization;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.TestPublicationDetails;
+import no.unit.nva.commons.json.JsonSerializable;
 
-//{
-//    "id" : "https://api.dev.nva.aws.unit.no/scientific-index/candidate/000012a8-7ebb-4d56-b02b-d5b0124eb70c",
-//    "isApplicable" : true,
-//    "type" : "NviCandidate",
-//    "identifier" : "000012a8-7ebb-4d56-b02b-d5b0124eb70c",
-//    "publicationDetails" : {
-//    "id" : "https://api.dev.nva.aws.unit.no/publication/019054d844c7-074e42ba-cf75-4bf8-8935-313b7f4d78b5",
-//    "type" : "AcademicArticle",
-//    "title" : "Comparison of sleep latency and number of SOREMPs in the home and hospital with a modified multiple
-//    sleep latency test: A randomized crossover study",
-//    "publicationDate" : {
-//    "year" : "2017"
-//    },
-//    "contributors" : [ {
-//    "type" : "NviContributor",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/398939",
-//    "name" : "Kornelia Katalin Beiske",
-//    "role" : "Creator",
-//    "affiliations" : [ {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
-//    "identifier" : "1972.40.8.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1972.0.0.0" ],
-//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
-//    } ]
-//    }, {
-//    "type" : "NviContributor",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
-//    "name" : "Trond Sand",
-//    "role" : "Creator",
-//    "affiliations" : [ {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0",
-//    "identifier" : "1920.16.0.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1920.0.0.0" ],
-//    "partOfIdentifiers" : [ "1920.16.0.0", "1920.0.0.0" ]
-//    }, {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0",
-//    "identifier" : "194.65.30.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/194.0.0.0" ],
-//    "partOfIdentifiers" : [ "194.65.0.0", "194.0.0.0" ]
-//    } ]
-//    }, {
-//    "type" : "NviContributor",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/405669",
-//    "name" : "Eyvind Rugland",
-//    "role" : "Creator",
-//    "affiliations" : [ {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
-//    "identifier" : "1972.40.8.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1972.0.0.0" ],
-//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
-//    } ]
-//    }, {
-//    "type" : "NviContributor",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
-//    "name" : "Knut Stavem",
-//    "role" : "Creator",
-//    "affiliations" : [ {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1",
-//    "identifier" : "1972.90.0.1",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1972.0.0.0" ],
-//    "partOfIdentifiers" : [ "1972.90.0.0", "1972.0.0.0" ]
-//    }, {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.5.0",
-//    "identifier" : "1972.40.5.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1972.0.0.0" ],
-//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
-//    }, {
-//    "type" : "NviOrganization",
-//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.82.0",
-//    "identifier" : "185.53.82.0",
-//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.80.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/185.90.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.0.0",
-//    "https://api.dev.nva.aws.unit.no/cristin/organization/185.50.0.0" ],
-//    "partOfIdentifiers" : [ "185.53.80.0", "185.90.0.0", "185.53.0.0", "185.50.0.0" ]
-//    } ]
-//    } ]
-//    },
-//    "approvals" : [ {
-//    "type" : "Approval",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0",
-//    "labels" : {
-//    "nb" : "St. Olavs Hospital HF",
-//    "en" : "St. Olavs Hospital, Trondheim University Hospital"
-//    },
-//    "approvalStatus" : "Approved",
-//    "points" : {
-//    "type" : "InstitutionPoints",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0",
-//    "institutionPoints" : 0.4082482905,
-//    "creatorAffiliationPoints" : [ {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0",
-//    "points" : 0.4082482905
-//    } ]
-//    },
-//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0", "https://api.dev
-//    .nva.aws.unit.no/cristin/organization/1920.16.0.0" ],
-//    "globalApprovalStatus" : "Approved"
-//    }, {
-//    "type" : "Approval",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-//    "labels" : {
-//    "nn" : "Noregs teknisk-naturvitskaplege universitet",
-//    "nb" : "Norges teknisk-naturvitenskapelige universitet",
-//    "en" : "Norwegian University of Science and Technology"
-//    },
-//    "approvalStatus" : "Approved",
-//    "points" : {
-//    "type" : "InstitutionPoints",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-//    "institutionPoints" : 0.4082482905,
-//    "creatorAffiliationPoints" : [ {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0",
-//    "points" : 0.4082482905
-//    } ]
-//    },
-//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0", "https://api
-//    .dev.nva.aws.unit.no/cristin/organization/194.0.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
-//    ],
-//    "globalApprovalStatus" : "Approved"
-//    }, {
-//    "type" : "Approval",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
-//    "labels" : {
-//    "nb" : "Universitetet i Oslo",
-//    "en" : "University of Oslo"
-//    },
-//    "approvalStatus" : "Approved",
-//    "points" : {
-//    "type" : "InstitutionPoints",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
-//    "institutionPoints" : 0.4082482905,
-//    "creatorAffiliationPoints" : [ {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.82.0",
-//    "points" : 0.4082482905
-//    } ]
-//    },
-//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.80.0", "https://api
-//    .dev.nva.aws.unit.no/cristin/organization/185.50.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
-//    "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.0.0", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/185.53.82.0" ],
-//    "globalApprovalStatus" : "Approved"
-//    }, {
-//    "type" : "Approval",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0",
-//    "labels" : {
-//    "nb" : "Akershus universitetssykehus HF",
-//    "en" : "Akershus University Hospital Trust"
-//    },
-//    "approvalStatus" : "Approved",
-//    "points" : {
-//    "type" : "InstitutionPoints",
-//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0",
-//    "institutionPoints" : 0.7071067812,
-//    "creatorAffiliationPoints" : [ {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/398939",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
-//    "points" : 0.2357022604
-//    }, {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/405669",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
-//    "points" : 0.2357022604
-//    }, {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.5.0",
-//    "points" : 0.1178511302
-//    }, {
-//    "type" : "CreatorAffiliationPoints",
-//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
-//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1",
-//    "points" : 0.1178511302
-//    } ]
-//    },
-//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api
-//    .dev.nva.aws.unit.no/cristin/organization/1972.40.8.0", "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.0",
-//    "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1", "https://api.dev.nva.aws.unit
-//    .no/cristin/organization/1972.40.5.0", "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0" ],
-//    "globalApprovalStatus" : "Approved"
-//    } ],
-//    "numberOfApprovals" : 4,
-//    "points" : 1.9318516527,
-//    "publicationTypeChannelLevelPoints" : 1,
-//    "globalApprovalStatus" : "Approved",
-//    "creatorShareCount" : 0,
-//    "internationalCollaborationFactor" : 1,
-//    "reportingPeriod" : {
-//    "type" : "ReportingPeriod",
-//    "year" : "2017"
-//    },
-//    "reported" : true,
-//    "createdDate" : "2024-06-27T16:59:26.173837245Z",
-//    "modifiedDate" : "2024-06-27T16:59:26.173837245Z",
-//    "@context" : "https://api.dev.nva.aws.unit.no/scientific-index/context"
-//    }
-
-public record NviIndexDocument(String id,
+public record NviIndexDocument(@JsonProperty("@context") String context,
+                               String id,
                                boolean isApplicable,
                                String type,
                                String identifier,
@@ -237,19 +30,19 @@ public record NviIndexDocument(String id,
                                double internationalCollaborationFactor,
                                ReportingPeriod reportingPeriod,
                                boolean reported,
-                               String modifiedDate,
-                               String context) {
+                               String modifiedDate) implements JsonSerializable {
 
     public static final String CONTEXT = "https://api.dev.nva.aws.unit.no/scientific-index/context";
     public static final String TYPE = "NviCandidate";
 
     public static NviIndexDocument from(TestNviCandidate nviCandidate) {
-        return new NviIndexDocument(nviCandidate.candidateUri(),
+        return new NviIndexDocument(CONTEXT,
+                                    nviCandidate.candidateUri(),
                                     nviCandidate.isApplicable(),
                                     TYPE,
                                     nviCandidate.identifier(),
                                     PublicationDetails.from(nviCandidate.publicationDetails()),
-                                    nviCandidate.approvals().stream().map(Approval::from).toList(),
+                                    generateApprovals(nviCandidate),
                                     nviCandidate.totalPoints().doubleValue(),
                                     nviCandidate.publicationTypeChannelLevelPoints().doubleValue(),
                                     nviCandidate.globalApprovalStatus().getValue(),
@@ -257,12 +50,18 @@ public record NviIndexDocument(String id,
                                     nviCandidate.internationalCollaborationFactor().doubleValue(),
                                     ReportingPeriod.from(nviCandidate.reportingPeriod()),
                                     nviCandidate.reported(),
-                                    nviCandidate.modifiedDate().toString(),
-                                    CONTEXT);
+                                    nviCandidate.modifiedDate().toString());
     }
 
     public JsonNode asJsonNode() {
-        return null;
+        return attempt(() -> dtoObjectMapper.readTree(this.toJsonString())).orElseThrow();
+    }
+
+    private static List<Approval> generateApprovals(TestNviCandidate nviCandidate) {
+        return nviCandidate.approvals()
+                   .stream()
+                   .map(testApproval -> Approval.from(testApproval, nviCandidate.globalApprovalStatus().getValue()))
+                   .toList();
     }
 
     private record ReportingPeriod(String type, String year) {
@@ -275,27 +74,51 @@ public record NviIndexDocument(String id,
     }
 
     private record Approval(String type,
-                            String institutionId,
-                            Map<String, String> labels,
+                            URI institutionId,
                             String approvalStatus,
                             Points points,
-                            List<String> involvedOrganizations,
+                            Set<String> involvedOrganizations,
                             String globalApprovalStatus) {
 
-        public static Approval from(TestApproval testApproval) {
-            return null;
+        public static final String TYPE = "Approval";
+
+        public static Approval from(TestApproval testApproval, String globalApprovalStatus) {
+            return new Approval(TYPE,
+                                testApproval.institutionId(),
+                                testApproval.approvalStatus().getValue(),
+                                Points.from(testApproval.points()),
+                                testApproval.involvedOrganizations(),
+                                globalApprovalStatus);
         }
 
         private record Points(String type,
-                              String institutionId,
                               double institutionPoints,
                               List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
+            public static final String TYPE = "InstitutionPoints";
+
+            public static Points from(TestInstitutionPoints points) {
+                return new Points(TYPE,
+                                  points.institutionPoints().doubleValue(),
+                                  points.creatorAffiliationPoints()
+                                      .stream()
+                                      .map(CreatorAffiliationPoints::from)
+                                      .toList());
+            }
+
             private record CreatorAffiliationPoints(String type,
-                                                    String nviCreator,
-                                                    String affiliationId,
+                                                    URI nviCreator,
+                                                    URI affiliationId,
                                                     double points) {
 
+                public static final String TYPE = "CreatorAffiliationPoints";
+
+                public static CreatorAffiliationPoints from(TestCreatorAffiliationPoints testCreatorAffiliationPoints) {
+                    return new CreatorAffiliationPoints(TYPE,
+                                                        testCreatorAffiliationPoints.nviCreator(),
+                                                        testCreatorAffiliationPoints.affiliationId(),
+                                                        testCreatorAffiliationPoints.points().doubleValue());
+                }
             }
         }
     }

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
@@ -23,11 +23,11 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                                String identifier,
                                PublicationDetails publicationDetails,
                                List<Approval> approvals,
-                               String points,
-                               String publicationTypeChannelLevelPoints,
+                               double points,
+                               double publicationTypeChannelLevelPoints,
                                String globalApprovalStatus,
                                int creatorShareCount,
-                               String internationalCollaborationFactor,
+                               double internationalCollaborationFactor,
                                ReportingPeriod reportingPeriod,
                                boolean reported,
                                String modifiedDate) implements JsonSerializable {
@@ -43,11 +43,11 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                                     nviCandidate.identifier(),
                                     PublicationDetails.from(nviCandidate.publicationDetails()),
                                     generateApprovals(nviCandidate),
-                                    nviCandidate.totalPoints().toString(),
-                                    nviCandidate.publicationTypeChannelLevelPoints().toString(),
+                                    nviCandidate.totalPoints().doubleValue(),
+                                    nviCandidate.publicationTypeChannelLevelPoints().doubleValue(),
                                     nviCandidate.globalApprovalStatus().getValue(),
                                     nviCandidate.creatorShareCount(),
-                                    nviCandidate.internationalCollaborationFactor().toString(),
+                                    nviCandidate.internationalCollaborationFactor().doubleValue(),
                                     ReportingPeriod.from(nviCandidate.reportingPeriod()),
                                     nviCandidate.reported(),
                                     nviCandidate.modifiedDate().toString());
@@ -92,14 +92,14 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
         }
 
         private record Points(String type,
-                              String institutionPoints,
+                              double institutionPoints,
                               List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
             public static final String TYPE = "InstitutionPoints";
 
             public static Points from(TestInstitutionPoints points) {
                 return new Points(TYPE,
-                                  points.institutionPoints().toString(),
+                                  points.institutionPoints().doubleValue(),
                                   points.creatorAffiliationPoints()
                                       .stream()
                                       .map(CreatorAffiliationPoints::from)
@@ -109,7 +109,7 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
             private record CreatorAffiliationPoints(String type,
                                                     URI nviCreator,
                                                     URI affiliationId,
-                                                    String points) {
+                                                    double points) {
 
                 public static final String TYPE = "CreatorAffiliationPoints";
 
@@ -117,7 +117,7 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                     return new CreatorAffiliationPoints(TYPE,
                                                         testCreatorAffiliationPoints.nviCreator(),
                                                         testCreatorAffiliationPoints.affiliationId(),
-                                                        testCreatorAffiliationPoints.points().toString());
+                                                        testCreatorAffiliationPoints.points().doubleValue());
                 }
             }
         }

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
@@ -1,0 +1,342 @@
+package no.sikt.nva.data.report.api.export;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestApproval;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviCandidate;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviContributor;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestNviOrganization;
+import no.sikt.nva.data.report.testing.utils.generator.nvi.TestPublicationDetails;
+
+//{
+//    "id" : "https://api.dev.nva.aws.unit.no/scientific-index/candidate/000012a8-7ebb-4d56-b02b-d5b0124eb70c",
+//    "isApplicable" : true,
+//    "type" : "NviCandidate",
+//    "identifier" : "000012a8-7ebb-4d56-b02b-d5b0124eb70c",
+//    "publicationDetails" : {
+//    "id" : "https://api.dev.nva.aws.unit.no/publication/019054d844c7-074e42ba-cf75-4bf8-8935-313b7f4d78b5",
+//    "type" : "AcademicArticle",
+//    "title" : "Comparison of sleep latency and number of SOREMPs in the home and hospital with a modified multiple
+//    sleep latency test: A randomized crossover study",
+//    "publicationDate" : {
+//    "year" : "2017"
+//    },
+//    "contributors" : [ {
+//    "type" : "NviContributor",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/398939",
+//    "name" : "Kornelia Katalin Beiske",
+//    "role" : "Creator",
+//    "affiliations" : [ {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
+//    "identifier" : "1972.40.8.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1972.0.0.0" ],
+//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
+//    } ]
+//    }, {
+//    "type" : "NviContributor",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
+//    "name" : "Trond Sand",
+//    "role" : "Creator",
+//    "affiliations" : [ {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0",
+//    "identifier" : "1920.16.0.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1920.0.0.0" ],
+//    "partOfIdentifiers" : [ "1920.16.0.0", "1920.0.0.0" ]
+//    }, {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0",
+//    "identifier" : "194.65.30.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/194.0.0.0" ],
+//    "partOfIdentifiers" : [ "194.65.0.0", "194.0.0.0" ]
+//    } ]
+//    }, {
+//    "type" : "NviContributor",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/405669",
+//    "name" : "Eyvind Rugland",
+//    "role" : "Creator",
+//    "affiliations" : [ {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
+//    "identifier" : "1972.40.8.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1972.0.0.0" ],
+//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
+//    } ]
+//    }, {
+//    "type" : "NviContributor",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
+//    "name" : "Knut Stavem",
+//    "role" : "Creator",
+//    "affiliations" : [ {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1",
+//    "identifier" : "1972.90.0.1",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1972.0.0.0" ],
+//    "partOfIdentifiers" : [ "1972.90.0.0", "1972.0.0.0" ]
+//    }, {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.5.0",
+//    "identifier" : "1972.40.5.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1972.0.0.0" ],
+//    "partOfIdentifiers" : [ "1972.40.0.0", "1972.0.0.0" ]
+//    }, {
+//    "type" : "NviOrganization",
+//    "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.82.0",
+//    "identifier" : "185.53.82.0",
+//    "partOf" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.80.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/185.90.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.0.0",
+//    "https://api.dev.nva.aws.unit.no/cristin/organization/185.50.0.0" ],
+//    "partOfIdentifiers" : [ "185.53.80.0", "185.90.0.0", "185.53.0.0", "185.50.0.0" ]
+//    } ]
+//    } ]
+//    },
+//    "approvals" : [ {
+//    "type" : "Approval",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0",
+//    "labels" : {
+//    "nb" : "St. Olavs Hospital HF",
+//    "en" : "St. Olavs Hospital, Trondheim University Hospital"
+//    },
+//    "approvalStatus" : "Approved",
+//    "points" : {
+//    "type" : "InstitutionPoints",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0",
+//    "institutionPoints" : 0.4082482905,
+//    "creatorAffiliationPoints" : [ {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1920.16.0.0",
+//    "points" : 0.4082482905
+//    } ]
+//    },
+//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1920.0.0.0", "https://api.dev
+//    .nva.aws.unit.no/cristin/organization/1920.16.0.0" ],
+//    "globalApprovalStatus" : "Approved"
+//    }, {
+//    "type" : "Approval",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+//    "labels" : {
+//    "nn" : "Noregs teknisk-naturvitskaplege universitet",
+//    "nb" : "Norges teknisk-naturvitenskapelige universitet",
+//    "en" : "Norwegian University of Science and Technology"
+//    },
+//    "approvalStatus" : "Approved",
+//    "points" : {
+//    "type" : "InstitutionPoints",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+//    "institutionPoints" : 0.4082482905,
+//    "creatorAffiliationPoints" : [ {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/43500",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0",
+//    "points" : 0.4082482905
+//    } ]
+//    },
+//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0", "https://api
+//    .dev.nva.aws.unit.no/cristin/organization/194.0.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+//    ],
+//    "globalApprovalStatus" : "Approved"
+//    }, {
+//    "type" : "Approval",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
+//    "labels" : {
+//    "nb" : "Universitetet i Oslo",
+//    "en" : "University of Oslo"
+//    },
+//    "approvalStatus" : "Approved",
+//    "points" : {
+//    "type" : "InstitutionPoints",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
+//    "institutionPoints" : 0.4082482905,
+//    "creatorAffiliationPoints" : [ {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.82.0",
+//    "points" : 0.4082482905
+//    } ]
+//    },
+//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.80.0", "https://api
+//    .dev.nva.aws.unit.no/cristin/organization/185.50.0.0", "https://api.dev.nva.aws.unit.no/cristin/organization/185.90.0.0",
+//    "https://api.dev.nva.aws.unit.no/cristin/organization/185.53.0.0", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/185.53.82.0" ],
+//    "globalApprovalStatus" : "Approved"
+//    }, {
+//    "type" : "Approval",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0",
+//    "labels" : {
+//    "nb" : "Akershus universitetssykehus HF",
+//    "en" : "Akershus University Hospital Trust"
+//    },
+//    "approvalStatus" : "Approved",
+//    "points" : {
+//    "type" : "InstitutionPoints",
+//    "institutionId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0",
+//    "institutionPoints" : 0.7071067812,
+//    "creatorAffiliationPoints" : [ {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/398939",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
+//    "points" : 0.2357022604
+//    }, {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/405669",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.8.0",
+//    "points" : 0.2357022604
+//    }, {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.5.0",
+//    "points" : 0.1178511302
+//    }, {
+//    "type" : "CreatorAffiliationPoints",
+//    "nviCreator" : "https://api.dev.nva.aws.unit.no/cristin/person/11988",
+//    "affiliationId" : "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1",
+//    "points" : 0.1178511302
+//    } ]
+//    },
+//    "involvedOrganizations" : [ "https://api.dev.nva.aws.unit.no/cristin/organization/1972.40.0.0", "https://api
+//    .dev.nva.aws.unit.no/cristin/organization/1972.40.8.0", "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.0",
+//    "https://api.dev.nva.aws.unit.no/cristin/organization/1972.90.0.1", "https://api.dev.nva.aws.unit
+//    .no/cristin/organization/1972.40.5.0", "https://api.dev.nva.aws.unit.no/cristin/organization/1972.0.0.0" ],
+//    "globalApprovalStatus" : "Approved"
+//    } ],
+//    "numberOfApprovals" : 4,
+//    "points" : 1.9318516527,
+//    "publicationTypeChannelLevelPoints" : 1,
+//    "globalApprovalStatus" : "Approved",
+//    "creatorShareCount" : 0,
+//    "internationalCollaborationFactor" : 1,
+//    "reportingPeriod" : {
+//    "type" : "ReportingPeriod",
+//    "year" : "2017"
+//    },
+//    "reported" : true,
+//    "createdDate" : "2024-06-27T16:59:26.173837245Z",
+//    "modifiedDate" : "2024-06-27T16:59:26.173837245Z",
+//    "@context" : "https://api.dev.nva.aws.unit.no/scientific-index/context"
+//    }
+
+public record NviIndexDocument(String id,
+                               boolean isApplicable,
+                               String type,
+                               String identifier,
+                               PublicationDetails publicationDetails,
+                               List<Approval> approvals,
+                               double points,
+                               double publicationTypeChannelLevelPoints,
+                               String globalApprovalStatus,
+                               int creatorShareCount,
+                               double internationalCollaborationFactor,
+                               ReportingPeriod reportingPeriod,
+                               boolean reported,
+                               String modifiedDate,
+                               String context) {
+
+    public static final String CONTEXT = "https://api.dev.nva.aws.unit.no/scientific-index/context";
+    public static final String TYPE = "NviCandidate";
+
+    public static NviIndexDocument from(TestNviCandidate nviCandidate) {
+        return new NviIndexDocument(nviCandidate.candidateUri(),
+                                    nviCandidate.isApplicable(),
+                                    TYPE,
+                                    nviCandidate.identifier(),
+                                    PublicationDetails.from(nviCandidate.publicationDetails()),
+                                    nviCandidate.approvals().stream().map(Approval::from).toList(),
+                                    nviCandidate.totalPoints().doubleValue(),
+                                    nviCandidate.publicationTypeChannelLevelPoints().doubleValue(),
+                                    nviCandidate.globalApprovalStatus().getValue(),
+                                    nviCandidate.creatorShareCount(),
+                                    nviCandidate.internationalCollaborationFactor().doubleValue(),
+                                    ReportingPeriod.from(nviCandidate.reportingPeriod()),
+                                    nviCandidate.reported(),
+                                    nviCandidate.modifiedDate().toString(),
+                                    CONTEXT);
+    }
+
+    public JsonNode asJsonNode() {
+        return null;
+    }
+
+    private record ReportingPeriod(String type, String year) {
+
+        public static final String TYPE = "ReportingPeriod";
+
+        public static ReportingPeriod from(String year) {
+            return new ReportingPeriod(TYPE, year);
+        }
+    }
+
+    private record Approval(String type,
+                            String institutionId,
+                            Map<String, String> labels,
+                            String approvalStatus,
+                            Points points,
+                            List<String> involvedOrganizations,
+                            String globalApprovalStatus) {
+
+        public static Approval from(TestApproval testApproval) {
+            return null;
+        }
+
+        private record Points(String type,
+                              String institutionId,
+                              double institutionPoints,
+                              List<CreatorAffiliationPoints> creatorAffiliationPoints) {
+
+            private record CreatorAffiliationPoints(String type,
+                                                    String nviCreator,
+                                                    String affiliationId,
+                                                    double points) {
+
+            }
+        }
+    }
+
+    private record PublicationDetails(String id,
+                                      List<NviContributor> contributors) {
+
+        public static PublicationDetails from(TestPublicationDetails testPublicationDetails) {
+            return new PublicationDetails(testPublicationDetails.id(),
+                                          testPublicationDetails.contributors().stream()
+                                              .map(NviContributor::from)
+                                              .toList());
+        }
+
+        private record NviContributor(String type,
+                                      String id,
+                                      List<NviOrganization> affiliations) {
+
+            public static final String TYPE = "NviContributor";
+
+            public static NviContributor from(TestNviContributor testNviContributor) {
+                return new NviContributor(TYPE,
+                                          testNviContributor.id(),
+                                          testNviContributor.affiliations()
+                                              .stream()
+                                              .map(NviOrganization::from)
+                                              .toList());
+            }
+
+            private record NviOrganization(String type,
+                                           String id,
+                                           List<String> partOf) {
+
+                public static final String TYPE = "NviOrganization";
+
+                public static NviOrganization from(TestNviOrganization testNviOrganization) {
+                    return new NviOrganization(TYPE,
+                                               testNviOrganization.id(),
+                                               testNviOrganization.partOf());
+                }
+            }
+        }
+    }
+}

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/NviIndexDocument.java
@@ -23,11 +23,11 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                                String identifier,
                                PublicationDetails publicationDetails,
                                List<Approval> approvals,
-                               double points,
-                               double publicationTypeChannelLevelPoints,
+                               String points,
+                               String publicationTypeChannelLevelPoints,
                                String globalApprovalStatus,
                                int creatorShareCount,
-                               double internationalCollaborationFactor,
+                               String internationalCollaborationFactor,
                                ReportingPeriod reportingPeriod,
                                boolean reported,
                                String modifiedDate) implements JsonSerializable {
@@ -43,11 +43,11 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                                     nviCandidate.identifier(),
                                     PublicationDetails.from(nviCandidate.publicationDetails()),
                                     generateApprovals(nviCandidate),
-                                    nviCandidate.totalPoints().doubleValue(),
-                                    nviCandidate.publicationTypeChannelLevelPoints().doubleValue(),
+                                    nviCandidate.totalPoints().toString(),
+                                    nviCandidate.publicationTypeChannelLevelPoints().toString(),
                                     nviCandidate.globalApprovalStatus().getValue(),
                                     nviCandidate.creatorShareCount(),
-                                    nviCandidate.internationalCollaborationFactor().doubleValue(),
+                                    nviCandidate.internationalCollaborationFactor().toString(),
                                     ReportingPeriod.from(nviCandidate.reportingPeriod()),
                                     nviCandidate.reported(),
                                     nviCandidate.modifiedDate().toString());
@@ -92,14 +92,14 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
         }
 
         private record Points(String type,
-                              double institutionPoints,
+                              String institutionPoints,
                               List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
             public static final String TYPE = "InstitutionPoints";
 
             public static Points from(TestInstitutionPoints points) {
                 return new Points(TYPE,
-                                  points.institutionPoints().doubleValue(),
+                                  points.institutionPoints().toString(),
                                   points.creatorAffiliationPoints()
                                       .stream()
                                       .map(CreatorAffiliationPoints::from)
@@ -109,7 +109,7 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
             private record CreatorAffiliationPoints(String type,
                                                     URI nviCreator,
                                                     URI affiliationId,
-                                                    double points) {
+                                                    String points) {
 
                 public static final String TYPE = "CreatorAffiliationPoints";
 
@@ -117,7 +117,7 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
                     return new CreatorAffiliationPoints(TYPE,
                                                         testCreatorAffiliationPoints.nviCreator(),
                                                         testCreatorAffiliationPoints.affiliationId(),
-                                                        testCreatorAffiliationPoints.points().doubleValue());
+                                                        testCreatorAffiliationPoints.points().toString());
                 }
             }
         }

--- a/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/NquadsTransformer.java
+++ b/bulk-load/src/main/java/no/sikt/nva/data/report/api/etl/transformer/NquadsTransformer.java
@@ -52,7 +52,7 @@ public class NquadsTransformer extends BulkTransformerHandler {
     }
 
     @Override
-    protected List<ContentWithLocation> processBatch(Stream<JsonNode> jsonNodeStream) {
+    protected List<ContentWithLocation> processBatch(Stream<JsonNode> jsonNodeStream, String batchLocation) {
         var nquads = jsonNodeStream.map(this::mapToNquads)
                          .collect(Collectors.joining(System.lineSeparator()));
         return List.of(new ContentWithLocation(UnixPath.ROOT_PATH, nquads));

--- a/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/NquadsTransformerTest.java
+++ b/bulk-load/src/test/java/no/sikt/nva/data/report/api/etl/transformer/NquadsTransformerTest.java
@@ -80,8 +80,8 @@ class NquadsTransformerTest {
         var batch = expectedDocuments.stream()
                         .map(IndexDocument::getDocumentIdentifier)
                         .collect(Collectors.joining(System.lineSeparator()));
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, batch);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -110,8 +110,8 @@ class NquadsTransformerTest {
             """;
         var documentIdentifier = "publicationIdentifier";
         s3ResourcesDriver.insertFile(UnixPath.of(documentIdentifier), json);
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), documentIdentifier);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, documentIdentifier);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -123,8 +123,8 @@ class NquadsTransformerTest {
 
     @Test
     void shouldSkipEmptyBatches() throws IOException {
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), StringUtils.EMPTY_STRING);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, StringUtils.EMPTY_STRING);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -141,8 +141,8 @@ class NquadsTransformerTest {
         var batch = expectedDocuments.stream()
                         .map(IndexDocument::getDocumentIdentifier)
                         .collect(Collectors.joining(System.lineSeparator()));
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, batch);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -159,14 +159,14 @@ class NquadsTransformerTest {
         var batch = expectedDocuments.stream()
                         .map(IndexDocument::getDocumentIdentifier)
                         .collect(Collectors.joining(System.lineSeparator()));
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
-        var expectedStarMarkerFromEmittedEvent = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(expectedStarMarkerFromEmittedEvent), batch);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, batch);
+        var expectedStarMarkerFromEmittedEvent = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(expectedStarMarkerFromEmittedEvent, batch);
         var list = new ArrayList<String>();
         list.add(null);
-        list.add(batchKey);
-        list.add(expectedStarMarkerFromEmittedEvent);
+        list.add(batchKey.toString());
+        list.add(expectedStarMarkerFromEmittedEvent.toString());
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -176,7 +176,7 @@ class NquadsTransformerTest {
 
             var emittedEvent = ((StubEventBridgeClient) eventBridgeClient).getLatestEvent();
 
-            assertEquals(batchKey, emittedEvent.getStartMarker());
+            assertEquals(batchKey.toString(), emittedEvent.getStartMarker());
             assertEquals(DEFAULT_LOCATION, emittedEvent.getLocation());
         }
     }
@@ -208,8 +208,8 @@ class NquadsTransformerTest {
         var batch = documents.stream()
                         .map(IndexDocument::getDocumentIdentifier)
                         .collect(Collectors.joining(System.lineSeparator()));
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, batch);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,
@@ -228,8 +228,8 @@ class NquadsTransformerTest {
         var batch = expectedDocuments.stream()
                         .map(IndexDocument::getDocumentIdentifier)
                         .collect(Collectors.joining(System.lineSeparator()));
-        var batchKey = randomString();
-        s3BatchesDriver.insertFile(UnixPath.of(batchKey), batch);
+        var batchKey = UnixPath.of(DEFAULT_LOCATION).addChild(randomString());
+        s3BatchesDriver.insertFile(batchKey, batch);
         var handler = new NquadsTransformer(s3ResourcesClient,
                                             s3BatchesClient,
                                             s3OutputClient,

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -1,10 +1,16 @@
 package commons.formatter;
 
-import static org.apache.commons.io.StandardLineSeparator.CRLF;
+import static java.util.Objects.isNull;
+import static nva.commons.core.StringUtils.EMPTY_STRING;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
 import java.util.List;
 import nva.commons.core.JacocoGenerated;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Literal;
@@ -13,76 +19,56 @@ import org.apache.jena.rdf.model.RDFNode;
 @JacocoGenerated //Tested in modules report-api and bulk-export
 public final class CsvFormatter implements ResponseFormatter {
 
-    public static final String DOUBLE_QUOTES = "\"";
     private static final String DECIMAL_PATTERN = "0.0000";
-    private static final String DELIMITER = ",";
     private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
     private static final String TYPE_DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
-    private static final String LINE_BREAK = CRLF.getString();
 
     @Override
     public String format(ResultSet resultSet) {
         var resultVars = resultSet.getResultVars();
+        var writer = new StringWriter();
+        try (CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+            printHeaders(csvPrinter, resultVars);
+            printRows(resultSet, resultVars, csvPrinter);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return writer.toString();
+    }
 
-        var csvBuilder = new StringBuilder();
-        appendHeaders(resultVars, csvBuilder);
-
+    private static void printRows(ResultSet resultSet, List<String> resultVars, CSVPrinter csvPrinter)
+        throws IOException {
         while (resultSet.hasNext()) {
-            appendResults(resultSet, resultVars, csvBuilder);
-        }
-
-        return csvBuilder.toString();
-    }
-
-    private static void appendHeaders(List<String> resultVars, StringBuilder csvBuilder) {
-        for (String var : resultVars) {
-            appendDouble(csvBuilder, var);
-        }
-        removeLastComma(csvBuilder);
-        appendLineBreak(csvBuilder);
-    }
-
-    private static void appendResults(ResultSet resultSet, List<String> resultVars, StringBuilder csvBuilder) {
-        var row = resultSet.next();
-        appendRow(resultVars, csvBuilder, row);
-        removeLastComma(csvBuilder);
-        appendLineBreak(csvBuilder);
-    }
-
-    private static void appendRow(List<String> resultVars, StringBuilder csvBuilder, QuerySolution row) {
-        for (String var : resultVars) {
-            var rdfNode = row.get(var);
-            if (rdfNode == null) {
-                appendEmptyString(csvBuilder);
-            } else if (isDoubleLiteral(rdfNode)) {
-                var formattedDouble = formatDouble(rdfNode.asLiteral());
-                appendDouble(csvBuilder, formattedDouble);
-            } else if (isIntegerLiteral(rdfNode)) {
-                appendInt(csvBuilder, rdfNode.asLiteral().getInt());
-            } else {
-                appendRdfNode(csvBuilder, rdfNode);
-            }
+            printRow(resultVars, csvPrinter, resultSet.next());
         }
     }
 
-    private static void appendEmptyString(StringBuilder csvBuilder) {
-        csvBuilder.append(DELIMITER);
+    private static void printRow(List<String> headers, CSVPrinter csvPrinter, QuerySolution querySolution)
+        throws IOException {
+        var rowData = new ArrayList<>();
+        headers.forEach(header -> buildRow(rowData, querySolution.get(header)));
+        csvPrinter.printRecord(rowData);
     }
 
-    private static void appendRdfNode(StringBuilder csvBuilder, RDFNode node) {
-        var nodeValue = node.toString();
-        if (nodeValue.contains(DELIMITER)) {
-            nodeValue = DOUBLE_QUOTES + nodeValue + DOUBLE_QUOTES;
+    private static void buildRow(ArrayList<Object> rowData, RDFNode rdfNode) {
+        addRdfNode(rdfNode, rowData);
+    }
+
+    private static void addRdfNode(RDFNode rdfNode, ArrayList<Object> rowData) {
+        if (isNull(rdfNode)) {
+            rowData.add(EMPTY_STRING);
+        } else if (isDoubleLiteral(rdfNode)) {
+            var formattedDouble = formatDouble(rdfNode.asLiteral());
+            rowData.add(formattedDouble);
+        } else if (isIntegerLiteral(rdfNode)) {
+            rowData.add(rdfNode.asLiteral().getInt());
+        } else {
+            rowData.add(rdfNode.toString());
         }
-        csvBuilder.append(nodeValue).append(DELIMITER);
     }
 
-    private static void appendDouble(StringBuilder csvBuilder, String value) {
-        csvBuilder.append(value).append(DELIMITER);
-    }
-
-    private static void appendInt(StringBuilder csvBuilder, int value) {
-        csvBuilder.append(value).append(DELIMITER);
+    private static void printHeaders(CSVPrinter csvPrinter, List<String> resultVars) throws IOException {
+        csvPrinter.printRecord(resultVars);
     }
 
     private static String formatDouble(Literal literal) {
@@ -107,13 +93,5 @@ public final class CsvFormatter implements ResponseFormatter {
 
     private static boolean isDouble(RDFNode rdfNode) {
         return TYPE_DOUBLE.equals(((Literal) rdfNode).getDatatypeURI());
-    }
-
-    private static void appendLineBreak(StringBuilder csvBuilder) {
-        csvBuilder.append(LINE_BREAK);
-    }
-
-    private static void removeLastComma(StringBuilder csvBuilder) {
-        csvBuilder.deleteCharAt(csvBuilder.length() - 1);
     }
 }

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -11,8 +11,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 
 @JacocoGenerated //Tested in modules report-api and bulk-export
-public class CsvFormatter implements ResponseFormatter {
+public final class CsvFormatter implements ResponseFormatter {
 
+    public static final String DOUBLE_QUOTES = "\"";
     private static final String DECIMAL_PATTERN = "0.0000";
     private static final String DELIMITER = ",";
     private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
@@ -69,7 +70,11 @@ public class CsvFormatter implements ResponseFormatter {
     }
 
     private static void appendRdfNode(StringBuilder csvBuilder, RDFNode node) {
-        csvBuilder.append(node).append(DELIMITER);
+        var nodeValue = node.toString();
+        if (nodeValue.contains(DELIMITER)) {
+            nodeValue = DOUBLE_QUOTES + nodeValue + DOUBLE_QUOTES;
+        }
+        csvBuilder.append(nodeValue).append(DELIMITER);
     }
 
     private static void appendDouble(StringBuilder csvBuilder, String value) {

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -45,19 +45,19 @@ public final class CsvFormatter implements ResponseFormatter {
 
     private static void printRow(CSVPrinter csvPrinter, List<String> headers, QuerySolution querySolution)
         throws IOException {
-        var rowData = new ArrayList<>();
+        var rowData = new ArrayList<String>();
         headers.forEach(header -> addHeaderValueInRow(rowData, querySolution.get(header)));
         csvPrinter.printRecord(rowData);
     }
 
-    private static void addHeaderValueInRow(ArrayList<Object> rowData, RDFNode rdfNode) {
+    private static void addHeaderValueInRow(List<String> rowData, RDFNode rdfNode) {
         if (isNull(rdfNode)) {
             rowData.add(EMPTY_STRING);
         } else if (isDoubleLiteral(rdfNode)) {
             var formattedDouble = formatDouble(rdfNode.asLiteral());
             rowData.add(formattedDouble);
         } else if (isIntegerLiteral(rdfNode)) {
-            rowData.add(rdfNode.asLiteral().getInt());
+            rowData.add(String.valueOf(rdfNode.asLiteral().getInt()));
         } else {
             rowData.add(rdfNode.toString());
         }

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -14,8 +14,6 @@ import org.apache.jena.rdf.model.RDFNode;
 public class CsvFormatter implements ResponseFormatter {
 
     private static final String DECIMAL_PATTERN = "0.0000";
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(DECIMAL_PATTERN,
-                                                                          DecimalFormatSymbols.getInstance());
     private static final String DELIMITER = ",";
     private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
     private static final String TYPE_DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
@@ -83,7 +81,7 @@ public class CsvFormatter implements ResponseFormatter {
     }
 
     private static String formatDouble(Literal literal) {
-        return DECIMAL_FORMAT.format(literal.getDouble());
+        return new DecimalFormat(DECIMAL_PATTERN, DecimalFormatSymbols.getInstance()).format(literal.getDouble());
     }
 
     private static boolean isIntegerLiteral(RDFNode rdfNode) {

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -1,17 +1,116 @@
 package commons.formatter;
 
-import java.io.ByteArrayOutputStream;
+import static org.apache.commons.io.StandardLineSeparator.CRLF;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.List;
 import nva.commons.core.JacocoGenerated;
+import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
-import org.apache.jena.query.ResultSetFormatter;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.RDFNode;
 
 @JacocoGenerated //Tested in modules report-api and bulk-export
 public class CsvFormatter implements ResponseFormatter {
 
+    private static final String DECIMAL_PATTERN = "0.0000";
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat(DECIMAL_PATTERN,
+                                                                          DecimalFormatSymbols.getInstance());
+    private static final String DELIMITER = ",";
+    private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
+    private static final String TYPE_DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
+    private static final String LINE_BREAK = CRLF.getString();
+
     @Override
     public String format(ResultSet resultSet) {
-        var outputStream = new ByteArrayOutputStream();
-        ResultSetFormatter.outputAsCSV(outputStream, resultSet);
-        return outputStream.toString();
+        var resultVars = resultSet.getResultVars();
+
+        var csvBuilder = new StringBuilder();
+        appendHeaders(resultVars, csvBuilder);
+
+        while (resultSet.hasNext()) {
+            appendResults(resultSet, resultVars, csvBuilder);
+        }
+
+        return csvBuilder.toString();
+    }
+
+    private static void appendHeaders(List<String> resultVars, StringBuilder csvBuilder) {
+        for (String var : resultVars) {
+            appendDouble(csvBuilder, var);
+        }
+        removeLastComma(csvBuilder);
+        appendLineBreak(csvBuilder);
+    }
+
+    private static void appendResults(ResultSet resultSet, List<String> resultVars, StringBuilder csvBuilder) {
+        var row = resultSet.next();
+        appendRow(resultVars, csvBuilder, row);
+        removeLastComma(csvBuilder);
+        appendLineBreak(csvBuilder);
+    }
+
+    private static void appendRow(List<String> resultVars, StringBuilder csvBuilder, QuerySolution row) {
+        for (String var : resultVars) {
+            var rdfNode = row.get(var);
+            if (rdfNode == null) {
+                appendEmptyString(csvBuilder);
+            } else if (isDoubleLiteral(rdfNode)) {
+                var formattedDouble = formatDouble(rdfNode.asLiteral());
+                appendDouble(csvBuilder, formattedDouble);
+            } else if (isIntegerLiteral(rdfNode)) {
+                appendInt(csvBuilder, rdfNode.asLiteral().getInt());
+            } else {
+                appendRdfNode(csvBuilder, rdfNode);
+            }
+        }
+    }
+
+    private static void appendEmptyString(StringBuilder csvBuilder) {
+        csvBuilder.append(DELIMITER);
+    }
+
+    private static void appendRdfNode(StringBuilder csvBuilder, RDFNode node) {
+        csvBuilder.append(node).append(DELIMITER);
+    }
+
+    private static void appendDouble(StringBuilder csvBuilder, String value) {
+        csvBuilder.append(value).append(DELIMITER);
+    }
+
+    private static void appendInt(StringBuilder csvBuilder, int value) {
+        csvBuilder.append(value).append(DELIMITER);
+    }
+
+    private static String formatDouble(Literal literal) {
+        return DECIMAL_FORMAT.format(literal.getDouble());
+    }
+
+    private static boolean isIntegerLiteral(RDFNode rdfNode) {
+        return isLiteral(rdfNode) && isInteger(rdfNode);
+    }
+
+    private static boolean isInteger(RDFNode rdfNode) {
+        return TYPE_INTEGER.equals(((Literal) rdfNode).getDatatypeURI());
+    }
+
+    private static boolean isLiteral(RDFNode rdfNode) {
+        return rdfNode instanceof Literal;
+    }
+
+    private static boolean isDoubleLiteral(RDFNode rdfNode) {
+        return isLiteral(rdfNode) && isDouble(rdfNode);
+    }
+
+    private static boolean isDouble(RDFNode rdfNode) {
+        return TYPE_DOUBLE.equals(((Literal) rdfNode).getDatatypeURI());
+    }
+
+    private static void appendLineBreak(StringBuilder csvBuilder) {
+        csvBuilder.append(LINE_BREAK);
+    }
+
+    private static void removeLastComma(StringBuilder csvBuilder) {
+        csvBuilder.deleteCharAt(csvBuilder.length() - 1);
     }
 }

--- a/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
+++ b/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
@@ -76,14 +76,14 @@ public abstract class BulkTransformerHandler extends EventHandler<KeyBatchReques
             .map(this::extractContent)
             .filter(keys -> !keys.isEmpty())
             .map(this::mapToIndexDocuments)
-            .map(this::processBatch)
+            .map((Stream<JsonNode> jsonNodeStream) -> processBatch(jsonNodeStream, location))
             .ifPresent(this::persist);
 
         logger.info(LAST_CONSUMED_BATCH, batchResponse.getKey());
         return null;
     }
 
-    protected abstract List<ContentWithLocation> processBatch(Stream<JsonNode> jsonNodeStream);
+    protected abstract List<ContentWithLocation> processBatch(Stream<JsonNode> jsonNodeStream, String batchLocation);
 
     protected abstract void persist(List<ContentWithLocation> content);
 

--- a/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
+++ b/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
@@ -44,6 +44,7 @@ public abstract class BulkTransformerHandler extends EventHandler<KeyBatchReques
     private static final String PROCESSING_BATCH_MESSAGE = "Processing batch: {}";
     private static final String LAST_CONSUMED_BATCH = "Last consumed batch: {}";
     private static final String LINE_BREAK = "\n";
+    private static final String DEFAULT_LOCATION = "resources";
     private final S3Client s3ResourcesClient;
     private final S3Client s3BatchesClient;
     private final EventBridgeClient eventBridgeClient;
@@ -131,10 +132,11 @@ public abstract class BulkTransformerHandler extends EventHandler<KeyBatchReques
     }
 
     private String getLocation(KeyBatchRequestEvent input) {
-        return nonNull(input) && nonNull(input.getLocation()) ? input.getLocation() : null;
+        return nonNull(input) && nonNull(input.getLocation()) ? input.getLocation() : DEFAULT_LOCATION;
     }
 
     private ListingResponse fetchSingleBatch(String location, String startMarker) {
+        logger.info("Fetching batch with location: {} and startMarker: {}", location, startMarker);
         var response = s3BatchesClient.listObjectsV2(
             ListObjectsV2Request.builder()
                 .bucket(KEY_BATCHES_BUCKET)

--- a/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
+++ b/data-report-commons/src/main/java/commons/handlers/BulkTransformerHandler.java
@@ -68,7 +68,7 @@ public abstract class BulkTransformerHandler extends EventHandler<KeyBatchReques
                                 Context context) {
         var startMarker = getStartMarker(input);
         var location = getLocation(input);
-        var batchResponse = fetchSingleBatch(startMarker);
+        var batchResponse = fetchSingleBatch(location, startMarker);
 
         emitNextEvent(batchResponse, location, context);
 
@@ -134,10 +134,11 @@ public abstract class BulkTransformerHandler extends EventHandler<KeyBatchReques
         return nonNull(input) && nonNull(input.getLocation()) ? input.getLocation() : null;
     }
 
-    private ListingResponse fetchSingleBatch(String startMarker) {
+    private ListingResponse fetchSingleBatch(String location, String startMarker) {
         var response = s3BatchesClient.listObjectsV2(
             ListObjectsV2Request.builder()
                 .bucket(KEY_BATCHES_BUCKET)
+                .prefix(location)
                 .startAfter(startMarker)
                 .maxKeys(1)
                 .build());

--- a/data-report-commons/src/main/java/commons/model/ReportType.java
+++ b/data-report-commons/src/main/java/commons/model/ReportType.java
@@ -30,7 +30,7 @@ public enum ReportType {
     public static List<ReportType> getAllTypesExcludingNviReport() {
         return Arrays.stream(values())
                    .filter(ReportType::isNotNviReportType)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     public String getType() {

--- a/data-report-commons/src/main/java/commons/model/ReportType.java
+++ b/data-report-commons/src/main/java/commons/model/ReportType.java
@@ -1,6 +1,7 @@
 package commons.model;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public enum ReportType {
@@ -26,8 +27,18 @@ public enum ReportType {
                    .orElseThrow(ReportType::getIllegalArgument);
     }
 
+    public static List<ReportType> getAllTypesExcludingNviReport() {
+        return Arrays.stream(values())
+                   .filter(ReportType::isNotNviReportType)
+                   .collect(Collectors.toList());
+    }
+
     public String getType() {
         return type;
+    }
+
+    private static boolean isNotNviReportType(ReportType reportType) {
+        return !reportType.equals(NVI);
     }
 
     private static IllegalArgumentException getIllegalArgument() {

--- a/data-report-commons/src/main/java/commons/model/ReportType.java
+++ b/data-report-commons/src/main/java/commons/model/ReportType.java
@@ -38,7 +38,7 @@ public enum ReportType {
     }
 
     private static boolean isNotNviReportType(ReportType reportType) {
-        return !reportType.equals(NVI);
+        return !NVI.equals(reportType);
     }
 
     private static IllegalArgumentException getIllegalArgument() {

--- a/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
+++ b/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
@@ -1,0 +1,29 @@
+package commons.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import nva.commons.core.ioutils.IoUtils;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.jupiter.api.Test;
+
+class CsvFormatterTest {
+
+    @Test
+    void shouldEscapeCommas() {
+        var model = ModelFactory.createDefaultModel();
+        var inputWithComma = "<http://example.org/subject> <http://example.org/predicate> \"value,with,commas\" .";
+        RDFDataMgr.read(model, IoUtils.stringToStream(inputWithComma), Lang.NTRIPLES);
+        var query = "SELECT * WHERE { ?s ?p ?o }";
+        try (var queryExecution = QueryExecutionFactory.create(query, model)) {
+            var resultSet = queryExecution.execSelect();
+            var actual = new CsvFormatter().format(resultSet);
+            var expected = """
+                s,p,o
+                http://example.org/subject,http://example.org/predicate,"value,with,commas"
+                """;
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
+++ b/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
@@ -1,5 +1,6 @@
 package commons.formatter;
 
+import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import nva.commons.core.ioutils.IoUtils;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -19,10 +20,10 @@ class CsvFormatterTest {
         try (var queryExecution = QueryExecutionFactory.create(query, model)) {
             var resultSet = queryExecution.execSelect();
             var actual = new CsvFormatter().format(resultSet);
-            var expected = """
-                s,p,o
-                http://example.org/subject,http://example.org/predicate,"value,with,commas"
-                """;
+            var expected = "s,p,o"
+                           + CRLF.getString()
+                           + "http://example.org/subject,http://example.org/predicate,\"value,with,commas\""
+                           + CRLF.getString();
             assertEquals(expected, actual);
         }
     }

--- a/data-report-commons/src/test/java/commons/model/ReportTypeTest.java
+++ b/data-report-commons/src/test/java/commons/model/ReportTypeTest.java
@@ -2,6 +2,7 @@ package commons.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 class ReportTypeTest {
@@ -11,6 +12,12 @@ class ReportTypeTest {
         var candidate = "publication";
         var reportType = ReportType.parse(candidate);
         assertEquals(ReportType.PUBLICATION, reportType);
+    }
+
+    @Test
+    void shouldNotReturnReportTypeNvi() {
+        var reportTypes = ReportType.getAllTypesExcludingNviReport();
+        assertTrue(reportTypes.stream().noneMatch(ReportType.NVI::equals));
     }
 
     @Test

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
@@ -101,6 +101,10 @@ public class TestData {
         return publicationTestData;
     }
 
+    public List<TestNviCandidate> getNviTestData() {
+        return nviTestData;
+    }
+
     public List<Model> getModels() {
         return models;
     }


### PR DESCRIPTION
Jira task: NP-46747 Database-dumps for initial import

Part three:

- For each key batch in `location` (/folder) _nvi_, `CsvBulkTransformer` creates csv file for nvi data and persists in folder `/nvi` in s3 bucket _data-report-csv-export_
- Also, fixed a bug in `BulkTransformerHandler`. Previously, the handler received `location` as input, but did not actually fetch the key batch from that given location. Added `location` as prefix when fetching single batch in `BulkTransformerHandler`.