### PR TITLE
Np 47403 SingleObjectDataLoader, generate publication reports

### DIFF
--- a/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/CsvTransformer.java
+++ b/bulk-export/src/main/java/no/sikt/nva/data/report/api/export/CsvTransformer.java
@@ -35,6 +35,7 @@ public class CsvTransformer extends BulkTransformerHandler {
     private static final String ENV_VAR_EXPORT_BUCKET = "EXPORT_BUCKET";
     private final S3Client s3OutputClient;
     private final String exportBucket;
+
     @JacocoGenerated
     public CsvTransformer() {
         this(defaultS3Client(), defaultS3Client(), defaultS3Client(), defaultEventBridgeClient());

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
@@ -262,8 +262,7 @@ class CsvTransformerTest {
     }
 
     private static IndexDocument toIndexDocument(TestPublication publication) {
-        return new IndexDocument(randomConsumptionAttribute(),
-                                 PublicationIndexDocument.from(publication).asJsonNode());
+        return new IndexDocument(randomConsumptionAttribute(), PublicationIndexDocument.from(publication).asJsonNode());
     }
 
     private static IndexDocument toIndexDocument(TestNviCandidate nviCandidate) {

--- a/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
+++ b/bulk-export/src/test/java/no/sikt/nva/data/report/api/export/CsvTransformerTest.java
@@ -93,7 +93,7 @@ class CsvTransformerTest {
     @ParameterizedTest
     @EnumSource(names = {"AFFILIATION", "CONTRIBUTOR", "FUNDING", "IDENTIFIER", "PUBLICATION"})
     void shouldWriteCsvFileToS3ForAllReportTypes(ReportType reportType) throws IOException {
-        var testData = new TestData(generateDatePairs(2));
+        var testData = new TestData(generateDatePairs(1));
         var batch = setupExistingBatch(testData, reportType);
         var location = PERSISTED_RESOURCES_PUBLICATIONS;
         var batchKey = UnixPath.of(location).addChild(randomString());

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
@@ -185,7 +185,7 @@ public class TestData {
         return headers + values;
     }
 
-    private static ArrayList<TestNviCandidate> generateNviData(TestPublication publication) {
+    private static List<TestNviCandidate> generateNviData(TestPublication publication) {
         var nviDataSet = new ArrayList<TestNviCandidate>();
         nviDataSet.add(generateNviCandidate(Instant.now(), publication));
         return nviDataSet;

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
@@ -122,7 +122,7 @@ public class TestData {
 
     public String getAffiliationResponseData() {
         var headers = String.join(DELIMITER, AFFILIATION_HEADERS) + CRLF.getString();
-        publicationTestData.sort(this::sortByPublicationUri);
+        sortByPublicationId();
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedAffiliationResponse)
                          .collect(Collectors.joining());
@@ -131,7 +131,7 @@ public class TestData {
 
     public String getContributorResponseData() {
         var headers = String.join(DELIMITER, CONTRIBUTOR_HEADERS) + CRLF.getString();
-        publicationTestData.sort(this::sortByPublicationUri);
+        sortByPublicationId();
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedContributorResponse)
                          .collect(Collectors.joining());
@@ -140,7 +140,7 @@ public class TestData {
 
     public String getFundingResponseData() {
         var headers = String.join(DELIMITER, FUNDING_HEADERS) + CRLF.getString();
-        publicationTestData.sort(this::sortByPublicationUri);
+        sortByPublicationId();
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedFundingResponse)
                          .collect(Collectors.joining());
@@ -149,7 +149,7 @@ public class TestData {
 
     public String getIdentifierResponseData() {
         var headers = String.join(DELIMITER, IDENTIFIER_HEADERS) + CRLF.getString();
-        publicationTestData.sort(this::sortByPublicationUri);
+        sortByPublicationId();
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedIdentifierResponse)
                          .collect(Collectors.joining());
@@ -158,7 +158,7 @@ public class TestData {
 
     public String getPublicationResponseData() {
         var headers = String.join(DELIMITER, PUBLICATION_HEADERS) + CRLF.getString();
-        publicationTestData.sort(this::sortByPublicationUri);
+        sortByPublicationId();
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedPublicationResponse)
                          .collect(Collectors.joining());
@@ -258,6 +258,12 @@ public class TestData {
         var id = URI.create(candidate.candidateUri());
         var model = candidate.generateModel();
         return new ViewCompiler(model).extractView(id);
+    }
+
+    private void sortByPublicationId() {
+        if (publicationTestData.size() > ONE) {
+            publicationTestData.sort(this::sortByPublicationUri);
+        }
     }
 
     private void sortContributors(List<TestNviCandidate> expectedCandidates) {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/TestData.java
@@ -53,7 +53,6 @@ public class TestData {
 
     public static final String SOME_TOP_LEVEL_IDENTIFIER = "10.0.0.0";
     public static final String SOME_SUB_UNIT_IDENTIFIER = "10.1.1.2";
-    public static final int ONE = 1;
     private static final String DELIMITER = ",";
     private static final List<String> AFFILIATION_HEADERS = List.of(PUBLICATION_ID, STATUS,
                                                                     PUBLICATION_IDENTIFIER,
@@ -102,8 +101,8 @@ public class TestData {
     public TestData() {
         this.models = new ArrayList<>();
         var publication = generatePublication(new PublicationDate("2024", "02", "02"), Instant.now());
-        this.publicationTestData = List.of(publication);
-        this.nviTestData = List.of(generateNviCandidate(Instant.now(), publication));
+        publicationTestData = generatePublicationData(publication);
+        this.nviTestData = generateNviData(publication);
         addPublicationDataToModel(publicationTestData);
         addNviDataToModel(nviTestData);
     }
@@ -122,7 +121,7 @@ public class TestData {
 
     public String getAffiliationResponseData() {
         var headers = String.join(DELIMITER, AFFILIATION_HEADERS) + CRLF.getString();
-        sortByPublicationId();
+        publicationTestData.sort(this::sortByPublicationUri);
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedAffiliationResponse)
                          .collect(Collectors.joining());
@@ -131,7 +130,7 @@ public class TestData {
 
     public String getContributorResponseData() {
         var headers = String.join(DELIMITER, CONTRIBUTOR_HEADERS) + CRLF.getString();
-        sortByPublicationId();
+        publicationTestData.sort(this::sortByPublicationUri);
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedContributorResponse)
                          .collect(Collectors.joining());
@@ -140,7 +139,7 @@ public class TestData {
 
     public String getFundingResponseData() {
         var headers = String.join(DELIMITER, FUNDING_HEADERS) + CRLF.getString();
-        sortByPublicationId();
+        publicationTestData.sort(this::sortByPublicationUri);
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedFundingResponse)
                          .collect(Collectors.joining());
@@ -149,7 +148,7 @@ public class TestData {
 
     public String getIdentifierResponseData() {
         var headers = String.join(DELIMITER, IDENTIFIER_HEADERS) + CRLF.getString();
-        sortByPublicationId();
+        publicationTestData.sort(this::sortByPublicationUri);
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedIdentifierResponse)
                          .collect(Collectors.joining());
@@ -158,7 +157,7 @@ public class TestData {
 
     public String getPublicationResponseData() {
         var headers = String.join(DELIMITER, PUBLICATION_HEADERS) + CRLF.getString();
-        sortByPublicationId();
+        publicationTestData.sort(this::sortByPublicationUri);
         var values = publicationTestData.stream()
                          .map(TestPublication::getExpectedPublicationResponse)
                          .collect(Collectors.joining());
@@ -167,9 +166,7 @@ public class TestData {
 
     public String getNviResponseData() {
         var headers = String.join(DELIMITER, NviTestData.NVI_HEADERS) + CRLF.getString();
-        if (nviTestData.size() > ONE) {
-            nviTestData.sort(this::sortByPublicationUri);
-        }
+        nviTestData.sort(this::sortByPublicationUri);
         sortContributors(nviTestData);
         var values = nviTestData.stream()
                          .map(TestNviCandidate::getExpectedResponse)
@@ -186,6 +183,12 @@ public class TestData {
                          .map(this::getExpectedNviInstitutionStatusResponse)
                          .collect(Collectors.joining());
         return headers + values;
+    }
+
+    private static ArrayList<TestNviCandidate> generateNviData(TestPublication publication) {
+        var nviDataSet = new ArrayList<TestNviCandidate>();
+        nviDataSet.add(generateNviCandidate(Instant.now(), publication));
+        return nviDataSet;
     }
 
     private static boolean isReportedInYear(String reportingYear, TestNviCandidate testNviCandidate) {
@@ -260,10 +263,10 @@ public class TestData {
         return new ViewCompiler(model).extractView(id);
     }
 
-    private void sortByPublicationId() {
-        if (publicationTestData.size() > ONE) {
-            publicationTestData.sort(this::sortByPublicationUri);
-        }
+    private List<TestPublication> generatePublicationData(TestPublication publication) {
+        var publicationDataSet = new ArrayList<TestPublication>();
+        publicationDataSet.add(publication);
+        return publicationDataSet;
     }
 
     private void sortContributors(List<TestNviCandidate> expectedCandidates) {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/IndexDocument.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/IndexDocument.java
@@ -21,6 +21,7 @@ public class IndexDocument implements JsonSerializable {
     public static final String CONSUMPTION_ATTRIBUTES = "consumptionAttributes";
     public static final String MISSING_IDENTIFIER_IN_RESOURCE = "Missing identifier in resource";
     public static final String NVI_INDEX = "nvi-candidates";
+    public static final String PUBLICATION_INDEX = "resources";
     @JsonProperty(CONSUMPTION_ATTRIBUTES)
     private final EventConsumptionAttributes consumptionAttributes;
     @JsonProperty(BODY)
@@ -37,9 +38,15 @@ public class IndexDocument implements JsonSerializable {
         return attempt(() -> objectMapper.readValue(json, IndexDocument.class)).orElseThrow();
     }
 
-    public static IndexDocument fromNviCandidate(NviIndexDocument nviIndexDocument) {
+    public static IndexDocument from(NviIndexDocument nviIndexDocument) {
         return new IndexDocument(new EventConsumptionAttributes(NVI_INDEX, nviIndexDocument.identifier()),
                                  nviIndexDocument.asJsonNode());
+    }
+
+    public static IndexDocument from(PublicationIndexDocument publicationIndexDocument) {
+        return new IndexDocument(
+            new EventConsumptionAttributes(PUBLICATION_INDEX, publicationIndexDocument.identifier()),
+            publicationIndexDocument.asJsonNode());
     }
 
     @JacocoGenerated

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/NviIndexDocument.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/NviIndexDocument.java
@@ -57,6 +57,10 @@ public record NviIndexDocument(@JsonProperty("@context") String context,
         return attempt(() -> dtoObjectMapper.readTree(this.toJsonString())).orElseThrow();
     }
 
+    public IndexDocument toIndexDocument() {
+        return IndexDocument.from(this);
+    }
+
     private static List<Approval> generateApprovals(TestNviCandidate nviCandidate) {
         return nviCandidate.approvals()
                    .stream()

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
@@ -46,6 +46,10 @@ public record PublicationIndexDocument(String type,
         return attempt(() -> dtoObjectMapper.readTree(this.toJsonString())).orElseThrow();
     }
 
+    public IndexDocument toIndexDocument() {
+        return IndexDocument.from(this);
+    }
+
     private static List<TestOrganization> generateTopLevelOrganizations(TestPublication publication) {
         return publication.getContributorAffiliations()
                    .stream()


### PR DESCRIPTION
Jira task: NP-47381 Generate csv-files on s3 for new and changed publications and nvi candidates

Part two:

- `SingleObjectDataLoader`, generate five csv-files ("affiliation", "contributor", "funding", "identifier", "publication") when receiving s3 events for new and changed publications
- File path contructed with following pattern: {reportType}/{identifier}-{timestamp}. Example: publication/865ea1eb-3fab-421e-8517-936672c8d8d1-2024-08-21T11:31:54.032116

Next PR:
- Log failures and DLQ for retries