### PR TITLE
DataLoadingHandler, remove VPC config

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -414,12 +414,6 @@ Resources:
     Properties:
       Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
       CodeUri: data-loading
-      VpcConfig:
-        SecurityGroupIds:
-          - !Ref LambdaSecurityGroup
-        SubnetIds:
-          - !Ref LambdaSubnet1
-          - !Ref LambdaSubnet2
       Policies:
         - !GetAtt S3ManagedPolicy.PolicyArn
         - !GetAtt NeptuneManagedPolicy.PolicyArn


### PR DESCRIPTION
DataLoadingHandler (SingleObjectDataLoader) does not need to be in VPC, since it is not loading data to Neptune anymore