### PR TITLE
Np 47403 PersistedResourcesEventRule, TransformPersistedResourceQueue

### DIFF
--- a/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformer.java
+++ b/data-loading/src/main/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformer.java
@@ -31,9 +31,9 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SingleObjectDataLoader implements RequestHandler<PersistedResourceEvent, Void> {
+public class PersistedResourceCsvTransformer implements RequestHandler<PersistedResourceEvent, Void> {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger(SingleObjectDataLoader.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(PersistedResourceCsvTransformer.class);
     public static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     public static final String API_HOST = "API_HOST";
     public static final String EXPORT_BUCKET = "EXPORT_BUCKET";
@@ -43,12 +43,12 @@ public class SingleObjectDataLoader implements RequestHandler<PersistedResourceE
     private final StorageWriter storageWriter;
 
     @JacocoGenerated
-    public SingleObjectDataLoader() {
+    public PersistedResourceCsvTransformer() {
         this(new S3StorageReader(new Environment().readEnv(EXPANDED_RESOURCES_BUCKET)),
              new S3StorageWriter(new Environment().readEnv(EXPORT_BUCKET)));
     }
 
-    public SingleObjectDataLoader(StorageReader<UnixPath> storageReader, StorageWriter storageWriter) {
+    public PersistedResourceCsvTransformer(StorageReader<UnixPath> storageReader, StorageWriter storageWriter) {
         LOGGER.info("Initializing SingleObjectDataLoader");
         this.storageReader = storageReader;
         this.storageWriter = storageWriter;

--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
@@ -49,7 +49,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-class SingleObjectDataLoaderTest {
+class PersistedResourceCsvTransformerTest {
 
     public static final String EXPORT_BUCKET = "exportBucket";
     private static final String GZIP_ENDING = ".gz";
@@ -57,7 +57,7 @@ class SingleObjectDataLoaderTest {
     private static final String RESOURCES_PATH = "resources";
     private static final String BUCKET_NAME = "notRelevant";
     private static Context context;
-    private static SingleObjectDataLoader handler;
+    private static PersistedResourceCsvTransformer handler;
     private static S3Driver s3ResourcesDriver;
     private S3Driver s3OutputDriver;
     private S3Client fakeS3ResourcesClient;
@@ -69,8 +69,8 @@ class SingleObjectDataLoaderTest {
         s3ResourcesDriver = new S3Driver(fakeS3ResourcesClient, BUCKET_NAME);
         var fakeS3OutputClient = new FakeS3Client();
         s3OutputDriver = new S3Driver(fakeS3OutputClient, EXPORT_BUCKET);
-        handler = new SingleObjectDataLoader(new S3StorageReader(fakeS3ResourcesClient, BUCKET_NAME),
-                                             new S3StorageWriter(fakeS3OutputClient, EXPORT_BUCKET));
+        handler = new PersistedResourceCsvTransformer(new S3StorageReader(fakeS3ResourcesClient, BUCKET_NAME),
+                                                      new S3StorageWriter(fakeS3OutputClient, EXPORT_BUCKET));
     }
 
     @Test
@@ -128,8 +128,8 @@ class SingleObjectDataLoaderTest {
     void shouldWriteFilesWithContentTypeAndEncoding() throws IOException {
         var event = setupExistingNviIndexDocumentAndCreateUpsertEvent(new TestData());
         var mockedS3OutputClient = mock(S3Client.class);
-        var handler = new SingleObjectDataLoader(new S3StorageReader(fakeS3ResourcesClient, BUCKET_NAME),
-                                                 new S3StorageWriter(mockedS3OutputClient, EXPORT_BUCKET));
+        var handler = new PersistedResourceCsvTransformer(new S3StorageReader(fakeS3ResourcesClient, BUCKET_NAME),
+                                                          new S3StorageWriter(mockedS3OutputClient, EXPORT_BUCKET));
         handler.handleRequest(event, context);
         var requestWithExpectedContentType = PutObjectRequest.builder()
                                                  .contentType("text/csv; charset=UTF-8")

--- a/template.yaml
+++ b/template.yaml
@@ -416,10 +416,10 @@ Resources:
             Method: get
             RestApiId: !Ref DataReportApi
 
-  DataLoadingHandler:
+  PersistedResourceCsvTransformer:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: no.sikt.nva.data.report.api.etl.SingleObjectDataLoader::handleRequest
+      Handler: no.sikt.nva.data.report.api.etl.PersistedResourceCsvTransformer::handleRequest
       CodeUri: data-loading
       Policies:
         - !GetAtt S3ManagedPolicy.PolicyArn

--- a/template.yaml
+++ b/template.yaml
@@ -111,6 +111,13 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt GenerateNviInstitutionReportDLQ.Arn
         maxReceiveCount: 5
+
+  TransformPersistedResourceQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt TransformPersistedResourceDLQ.Arn
+        maxReceiveCount: 5
       # ---- DLQs ----
   GenerateNviInstitutionReportDLQ:
     Type: AWS::SQS::Queue
@@ -120,7 +127,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600 #14 days
-  DataLoadingDLQ:
+  TransformPersistedResourceDLQ:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600 #14 days
@@ -301,8 +308,8 @@ Resources:
               - prefix: !Ref NviCandidatesPrefix
       State: ENABLED
       Targets:
-        - Arn: !GetAtt DataLoadingHandler.Arn
-          Id: "DataLoadingHandler"
+        - Arn: !GetAtt TransformPersistedResourceQueue.Arn
+          Id: "TransformPersistedResourceQueue"
           InputTransformer:
             InputPathsMap:
               bucketName: "$.detail.bucket.name"
@@ -419,7 +426,7 @@ Resources:
         - !GetAtt NeptuneManagedPolicy.PolicyArn
         - !GetAtt SqsManagedPolicy.PolicyArn
         - !GetAtt DeployToVpnPolicy.PolicyArn
-      Timeout: 600
+      Timeout: 30
       MemorySize: 1536
       AutoPublishAlias: live
       Environment:
@@ -428,11 +435,16 @@ Resources:
           BACKEND_CLIENT_SECRET_NAME: 'BackendCognitoClientCredentials'
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
           EXPORT_BUCKET: !Ref ExportBucket
+      Events:
+        SqsEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt TransformPersistedResourceQueue.Arn
       EventInvokeConfig:
         DestinationConfig:
           OnFailure:
             Type: SQS
-            Destination: !GetAtt DataLoadingDLQ.Arn
+            Destination: !GetAtt TransformPersistedResourceDLQ.Arn
 
   BulkDataLoader:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Changes:
- Rename `SingleObjectDataLoader` to `PersistedResourceCsvTransformer`
- Changed target for `PersistedResourcesEventRule`, now targeting `TransformPersistedResourceQueue` (which `PersistedResourceCsvTransformer` consumes messages from). In this way, if `PersistedResourceCsvTransformer` fails, messages are sent to DLQ, and can be moved to `TransformPersistedResourceQueue` for a retry (with a DLQ _redrive_)