### PR TITLE
DataWarehouseRole: Make self-assuming

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -147,7 +147,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Ref DataWarehouseDataBricksArn
+              AWS:
+              - !Ref DataWarehouseDataBricksArn
+              - 'arn:aws:iam::${AWS::AccountId}:role/DataWarehouseRole'
             Action: sts:AssumeRole
             Condition:
               StringEquals:


### PR DESCRIPTION
Step 3 in [Create a storage credential for connecting to AWS S3](https://docs.databricks.com/en/connect/unity-catalog/storage-credentials.html#create-a-storage-credential-for-connecting-to-aws-s3)

Change:
- Make the trust relationship policy self-assuming