### PR TITLE
CsvFormatter: Quote mode minimal

### DIFF
--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -11,6 +11,7 @@ import java.util.List;
 import nva.commons.core.JacocoGenerated;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Literal;
@@ -22,12 +23,15 @@ public final class CsvFormatter implements ResponseFormatter {
     private static final String DECIMAL_PATTERN = "0.0000";
     private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
     private static final String TYPE_DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
+    private static final CSVFormat CSV_FORMAT = CSVFormat.Builder.create()
+                                                    .setQuoteMode(QuoteMode.MINIMAL)
+                                                    .build();
 
     @Override
     public String format(ResultSet resultSet) {
         var headers = resultSet.getResultVars();
         var stringWriter = new StringWriter();
-        try (CSVPrinter csvPrinter = new CSVPrinter(stringWriter, CSVFormat.DEFAULT)) {
+        try (CSVPrinter csvPrinter = new CSVPrinter(stringWriter, CSV_FORMAT)) {
             printHeaders(csvPrinter, headers);
             printRows(csvPrinter, resultSet, headers);
         } catch (IOException ioException) {

--- a/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
+++ b/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
@@ -27,4 +27,22 @@ class CsvFormatterTest {
             assertEquals(expected, actual);
         }
     }
+
+    @Test
+    void shouldQuoteNewLineValues() {
+        var model = ModelFactory.createDefaultModel();
+        var inputWithNewLine = "<http://example.org/subject> <http://example.org/predicate> "
+                               + "\"value\\r\\nwith\\r\\nnewLine\" .";
+        RDFDataMgr.read(model, IoUtils.stringToStream(inputWithNewLine), Lang.NTRIPLES);
+        var query = "SELECT * WHERE { ?s ?p ?o }";
+        try (var queryExecution = QueryExecutionFactory.create(query, model)) {
+            var resultSet = queryExecution.execSelect();
+            var actual = new CsvFormatter().format(resultSet);
+            var expected = "s,p,o"
+                           + CRLF.getString()
+                           + "http://example.org/subject,http://example.org/predicate,\"value\r\nwith\r\nnewLine\""
+                           + CRLF.getString();
+            assertEquals(expected, actual);
+        }
+    }
 }


### PR DESCRIPTION
Jira task: NP-47696 All reports: quote all special strings

Data plattform struggling to consume publications with titles like _The Athletics Injury Prevention Programme Can\r\nHelp to Reduce the Occurrence at Short Term of\r\nParticipation Restriction Injury Complaints in\r\nAthletics: A Prospective Cohort Study_
Our data should be washed properly, but if this is not the case, these strings should be quoted during export.

Quote mode `MINIMAL`: Quotes fields which contain special characters such as a the field delimiter, quote character or any of the characters in the line separator string.