### PR TITLE
Np 47673 Identifier report: Additional identifiers

### DIFF
--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
@@ -92,6 +92,16 @@ class PersistedResourceCsvTransformerTest {
     }
 
     @Test
+    void shouldNotExportHandleIdentifiers() throws IOException {
+        var testData = new SampleData();
+        var event = setUpExistingPublicationIndexDocumentAndCreateUpsertEvent(testData);
+        handler.handleRequest(event, context);
+        var expected = testData.getIdentifierResponseData();
+        var actual = getActualPersistedFile(IDENTIFIER);
+        assertEqualsInAnyOrder(expected, actual);
+    }
+
+    @Test
     void shouldFetchPublicationIndexDocumentAndTransformToExpectedNumberOfFiles()
         throws IOException {
         var event = setUpExistingPublicationIndexDocumentAndCreateUpsertEvent(new SampleData());

--- a/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
+++ b/data-loading/src/test/java/no/sikt/nva/data/report/api/etl/PersistedResourceCsvTransformerTest.java
@@ -80,7 +80,7 @@ class PersistedResourceCsvTransformerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(names = {"IDENTIFIER"})
+    @EnumSource(names = {"AFFILIATION", "CONTRIBUTOR", "FUNDING", "IDENTIFIER", "PUBLICATION"})
     void shouldFetchPublicationIndexDocumentAndTransformToKnownReportTypeAsCsvInExportBucket(ReportType reportType)
         throws IOException {
         var testData = new SampleData();

--- a/data-report-commons/src/main/resources/template/identifier.sparql
+++ b/data-report-commons/src/main/resources/template/identifier.sparql
@@ -6,7 +6,7 @@ SELECT DISTINCT
     ?publicationId
     ?status
     ?publicationIdentifier
-    ?additionalIdentifierSource
+    ?additionalIdentifierSourceName
     ?additionalIdentifier
     ?additionalIdentifierType
     ?modifiedDate
@@ -22,7 +22,7 @@ WHERE {
     BIND(STR(?modifiedDateRaw) AS ?modifiedDate)
 
     ?additionalIdentifierNode a ?additionalIdentifierTypeRaw .
-    ?additionalIdentifierNode :sourceName ?additionalIdentifierSource .
+    ?additionalIdentifierNode :sourceName ?additionalIdentifierSourceName .
     ?additionalIdentifierNode :value ?additionalIdentifier .
     BIND(REPLACE(STR(?additionalIdentifierTypeRaw), "https://nva.sikt.no/ontology/publication#", "", "i") AS ?additionalIdentifierType)
 }

--- a/data-report-commons/src/main/resources/template/identifier.sparql
+++ b/data-report-commons/src/main/resources/template/identifier.sparql
@@ -24,5 +24,8 @@ WHERE {
     ?additionalIdentifierNode a ?additionalIdentifierTypeRaw .
     ?additionalIdentifierNode :sourceName ?additionalIdentifierSourceName .
     ?additionalIdentifierNode :value ?additionalIdentifier .
+
+    FILTER(?additionalIdentifierTypeRaw != "HandleIdentifier")
+    FILTER(?additionalIdentifierSourceName != "handle")
     BIND(REPLACE(STR(?additionalIdentifierTypeRaw), "https://nva.sikt.no/ontology/publication#", "", "i") AS ?additionalIdentifierType)
 }

--- a/data-report-commons/src/main/resources/template/identifier.sparql
+++ b/data-report-commons/src/main/resources/template/identifier.sparql
@@ -8,6 +8,7 @@ SELECT DISTINCT
     ?publicationIdentifier
     ?additionalIdentifierSource
     ?additionalIdentifier
+    ?additionalIdentifierType
     ?modifiedDate
 WHERE {
     ?uri a :Publication ;
@@ -20,6 +21,8 @@ WHERE {
     BIND(REPLACE(STR(?publicationStatus), "https://nva.sikt.no/ontology/publication#", "", "i") AS ?status)
     BIND(STR(?modifiedDateRaw) AS ?modifiedDate)
 
+    ?additionalIdentifierNode a ?additionalIdentifierTypeRaw .
     ?additionalIdentifierNode :sourceName ?additionalIdentifierSource .
     ?additionalIdentifierNode :value ?additionalIdentifier .
+    BIND(REPLACE(STR(?additionalIdentifierTypeRaw), "https://nva.sikt.no/ontology/publication#", "", "i") AS ?additionalIdentifierType)
 }

--- a/data-report-commons/src/main/resources/template/identifier.sparql
+++ b/data-report-commons/src/main/resources/template/identifier.sparql
@@ -6,21 +6,20 @@ SELECT DISTINCT
     ?publicationId
     ?status
     ?publicationIdentifier
-    ?fundingSource
-    ?fundingId
+    ?additionalIdentifierSource
+    ?additionalIdentifier
     ?modifiedDate
 WHERE {
     ?uri a :Publication ;
                     :status ?publicationStatus ;
                     :modifiedDate ?modifiedDateRaw ;
                     :identifier ?publicationIdentifier ;
-                    :funding ?funding .
+                    :additionalIdentifier ?additionalIdentifierNode .
 
     BIND(STR(?uri) AS ?publicationId)
     BIND(REPLACE(STR(?publicationStatus), "https://nva.sikt.no/ontology/publication#", "", "i") AS ?status)
     BIND(STR(?modifiedDateRaw) AS ?modifiedDate)
 
-    ?funding :source ?source .
-    ?source :identifier ?fundingSource .
-    BIND(IF(isBlank(?funding), "", STR(?funding)) AS ?fundingId)
+    ?additionalIdentifierNode :sourceName ?additionalIdentifierSource .
+    ?additionalIdentifierNode :value ?additionalIdentifier .
 }

--- a/documentation/identifierReport.md
+++ b/documentation/identifierReport.md
@@ -15,7 +15,7 @@
   - type: string
   - description: The sortable identifier of the publication
   - example: 018a8931a9d8-910a8ae0-77fd-4dba-ab12-efe82279b44e
-- `additionalIdentifierSource`
+- `additionalIdentifierSourceName`
   - type: string
   - description: The source of the additional identifier
   - example: Cristin

--- a/documentation/identifierReport.md
+++ b/documentation/identifierReport.md
@@ -15,14 +15,14 @@
   - type: string
   - description: The sortable identifier of the publication
   - example: 018a8931a9d8-910a8ae0-77fd-4dba-ab12-efe82279b44e
-- `fundingSource`
+- `additionalIdentifierSource`
   - type: string
-  - description: The source of the funding
-  - example: NFR
-- `fundingId`
-  - type: URI
-  - description: The resource uri of the funding
-  - example: <https://api.nva.unit.no/verified-funding/nfr/123456>
+  - description: The source of the additional identifier
+  - example: Cristin
+- `additionalIdentifier`
+  - type: string
+  - description: The additional identifier value
+  - example: 2-s2.0-80051784603
 - `modifiedDate`
   - type: string
   - description: The last modified date of the publication. ISO 8601 format

--- a/documentation/identifierReport.md
+++ b/documentation/identifierReport.md
@@ -23,6 +23,12 @@
   - type: string
   - description: The additional identifier value
   - example: 2-s2.0-80051784603
+- `additionalIdentifierType`
+  - type: string
+  - enum:
+    See [AdditionalIdentifierBase-subtypes](https://github.com/BIBSYSDEV/nva-publication-api/blob/main/publication-model/src/main/java/no/unit/nva/model/additionalidentifiers/AdditionalIdentifierBase.java)
+  - description: The type of the additional identifier
+  - example: ScopusIdentifier
 - `modifiedDate`
   - type: string
   - description: The last modified date of the publication. ISO 8601 format

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
@@ -11,6 +11,8 @@ public final class PublicationHeaders {
     public static final String CONTRIBUTOR_ROLE = "contributorRole";
     public static final String CONTRIBUTOR_ID = "contributorId";
     public static final String CONTRIBUTOR_NAME = "contributorName";
+    public static final String ADDITIONAL_IDENTIFIER = "additionalIdentifier";
+    public static final String ADDITIONAL_IDENTIFIER_SOURCE = "additionalIdentifierSource";
     public static final String AFFILIATION_ID = "affiliationId";
     public static final String AFFILIATION_NAME = "affiliationName";
     public static final String INSTITUTION_ID = "institutionId";

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
@@ -13,6 +13,7 @@ public final class PublicationHeaders {
     public static final String CONTRIBUTOR_NAME = "contributorName";
     public static final String ADDITIONAL_IDENTIFIER = "additionalIdentifier";
     public static final String ADDITIONAL_IDENTIFIER_SOURCE = "additionalIdentifierSource";
+    public static final String ADDITIONAL_IDENTIFIER_TYPE = "additionalIdentifierType";
     public static final String AFFILIATION_ID = "affiliationId";
     public static final String AFFILIATION_NAME = "affiliationName";
     public static final String INSTITUTION_ID = "institutionId";

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/PublicationHeaders.java
@@ -12,7 +12,7 @@ public final class PublicationHeaders {
     public static final String CONTRIBUTOR_ID = "contributorId";
     public static final String CONTRIBUTOR_NAME = "contributorName";
     public static final String ADDITIONAL_IDENTIFIER = "additionalIdentifier";
-    public static final String ADDITIONAL_IDENTIFIER_SOURCE = "additionalIdentifierSource";
+    public static final String ADDITIONAL_IDENTIFIER_SOURCE = "additionalIdentifierSourceName";
     public static final String ADDITIONAL_IDENTIFIER_TYPE = "additionalIdentifierType";
     public static final String AFFILIATION_ID = "affiliationId";
     public static final String AFFILIATION_NAME = "affiliationName";

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
@@ -4,6 +4,7 @@ import static no.sikt.nva.data.report.testing.utils.generator.Constants.organiza
 import static no.sikt.nva.data.report.testing.utils.generator.NviSampleData.generateNviCandidate;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.ADDITIONAL_IDENTIFIER;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.ADDITIONAL_IDENTIFIER_SOURCE;
+import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.ADDITIONAL_IDENTIFIER_TYPE;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.AFFILIATION_ID;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.AFFILIATION_NAME;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.CHANNEL_IDENTIFIER;
@@ -92,6 +93,7 @@ public class SampleData {
     private static final List<String> IDENTIFIER_HEADERS = List.of(PUBLICATION_ID, STATUS,
                                                                    PUBLICATION_IDENTIFIER,
                                                                    ADDITIONAL_IDENTIFIER_SOURCE,
+                                                                   ADDITIONAL_IDENTIFIER_TYPE,
                                                                    ADDITIONAL_IDENTIFIER,
                                                                    MODIFIED_DATE);
     private final List<SamplePublication> publicationTestData;
@@ -197,7 +199,8 @@ public class SampleData {
     private static SampleAdditionalIdentifier generateAdditionalIdentifier() {
         return new SampleAdditionalIdentifier()
                    .withSourceName("Cristin")
-                   .withValue(randomString());
+                   .withValue(randomString())
+                   .withType("CristinIdentifier");
     }
 
     private static SampleChannel generateChannel() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
@@ -93,8 +93,8 @@ public class SampleData {
     private static final List<String> IDENTIFIER_HEADERS = List.of(PUBLICATION_ID, STATUS,
                                                                    PUBLICATION_IDENTIFIER,
                                                                    ADDITIONAL_IDENTIFIER_SOURCE,
-                                                                   ADDITIONAL_IDENTIFIER_TYPE,
                                                                    ADDITIONAL_IDENTIFIER,
+                                                                   ADDITIONAL_IDENTIFIER_TYPE,
                                                                    MODIFIED_DATE);
     private final List<SamplePublication> publicationTestData;
     private final List<SampleNviCandidate> nviTestData;

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
@@ -2,6 +2,8 @@ package no.sikt.nva.data.report.testing.utils.generator;
 
 import static no.sikt.nva.data.report.testing.utils.generator.Constants.organizationUri;
 import static no.sikt.nva.data.report.testing.utils.generator.NviSampleData.generateNviCandidate;
+import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.ADDITIONAL_IDENTIFIER;
+import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.ADDITIONAL_IDENTIFIER_SOURCE;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.AFFILIATION_ID;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.AFFILIATION_NAME;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.CHANNEL_IDENTIFIER;
@@ -29,6 +31,7 @@ import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.PUBLICATION_IDENTIFIER;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.PUBLICATION_TITLE;
 import static no.sikt.nva.data.report.testing.utils.generator.PublicationHeaders.STATUS;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import java.time.Instant;
@@ -39,6 +42,7 @@ import java.util.stream.Collectors;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.SampleNviCandidate;
 import no.sikt.nva.data.report.testing.utils.generator.nvi.SampleNviContributor;
 import no.sikt.nva.data.report.testing.utils.generator.publication.PublicationDate;
+import no.sikt.nva.data.report.testing.utils.generator.publication.SampleAdditionalIdentifier;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleChannel;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleContributor;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleFunding;
@@ -87,7 +91,8 @@ public class SampleData {
                                                                     MODIFIED_DATE);
     private static final List<String> IDENTIFIER_HEADERS = List.of(PUBLICATION_ID, STATUS,
                                                                    PUBLICATION_IDENTIFIER,
-                                                                   FUNDING_SOURCE, FUNDING_ID,
+                                                                   ADDITIONAL_IDENTIFIER_SOURCE,
+                                                                   ADDITIONAL_IDENTIFIER,
                                                                    MODIFIED_DATE);
     private final List<SamplePublication> publicationTestData;
     private final List<SampleNviCandidate> nviTestData;
@@ -185,7 +190,14 @@ public class SampleData {
                    .withPublicationTitle("My study")
                    .withPublicationCategory("AcademicArticle")
                    .withPublicationDate(date)
-                   .withChannel(generateChannel());
+                   .withChannel(generateChannel())
+                   .withAdditionalIdentifiers(List.of(generateAdditionalIdentifier()));
+    }
+
+    private static SampleAdditionalIdentifier generateAdditionalIdentifier() {
+        return new SampleAdditionalIdentifier()
+                   .withSourceName("Cristin")
+                   .withValue(randomString());
     }
 
     private static SampleChannel generateChannel() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/SampleData.java
@@ -193,7 +193,14 @@ public class SampleData {
                    .withPublicationCategory("AcademicArticle")
                    .withPublicationDate(date)
                    .withChannel(generateChannel())
-                   .withAdditionalIdentifiers(List.of(generateAdditionalIdentifier()));
+                   .withAdditionalIdentifiers(List.of(generateAdditionalIdentifier(), generateHandleIdentifier()));
+    }
+
+    private static SampleAdditionalIdentifier generateHandleIdentifier() {
+        return new SampleAdditionalIdentifier()
+                   .withSourceName("handle")
+                   .withValue(randomUri().toString())
+                   .withType("HandleIdentifier");
     }
 
     private static SampleAdditionalIdentifier generateAdditionalIdentifier() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SampleAdditionalIdentifier.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SampleAdditionalIdentifier.java
@@ -4,6 +4,7 @@ public class SampleAdditionalIdentifier {
 
     private String sourceName;
     private String value;
+    private String type;
 
     public SampleAdditionalIdentifier() {
     }
@@ -18,11 +19,20 @@ public class SampleAdditionalIdentifier {
         return this;
     }
 
+    public SampleAdditionalIdentifier withType(String type) {
+        this.type = type;
+        return this;
+    }
+
     public String getSourceName() {
         return sourceName;
     }
 
     public String getValue() {
         return value;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SampleAdditionalIdentifier.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SampleAdditionalIdentifier.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.data.report.testing.utils.generator.publication;
+
+public class SampleAdditionalIdentifier {
+
+    private String sourceName;
+    private String value;
+
+    public SampleAdditionalIdentifier() {
+    }
+
+    public SampleAdditionalIdentifier withSourceName(String sourceName) {
+        this.sourceName = sourceName;
+        return this;
+    }
+
+    public SampleAdditionalIdentifier withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -204,7 +204,7 @@ public class SamplePublication {
     }
 
     private static Predicate<SampleAdditionalIdentifier> isNotHandleIdentifier() {
-        return additionalIdentifier -> additionalIdentifier.getType().equals("HandleIdentifier");
+        return additionalIdentifier -> !additionalIdentifier.getType().equals("HandleIdentifier");
     }
 
     public String getExpectedPublicationResponse() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -204,7 +204,7 @@ public class SamplePublication {
     }
 
     private static Predicate<SampleAdditionalIdentifier> isNotHandleIdentifier() {
-        return additionalIdentifier -> !additionalIdentifier.getType().equals("HandleIdentifier");
+        return additionalIdentifier -> !"HandleIdentifier".equals(additionalIdentifier.getType());
     }
 
     public String getExpectedPublicationResponse() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class SamplePublication {
@@ -189,16 +190,21 @@ public class SamplePublication {
 
     public String getExpectedIdentifierResponse() {
         var stringBuilder = new StringBuilder();
-        for (SampleAdditionalIdentifier additionalIdentifier : additionalIdentifiers) {
-            stringBuilder.append(publicationUri).append(DELIMITER)
-                .append(publicationStatus).append(DELIMITER)
-                .append(identifier).append(DELIMITER)
-                .append(additionalIdentifier.getSourceName()).append(DELIMITER)
-                .append(additionalIdentifier.getValue()).append(DELIMITER)
-                .append(additionalIdentifier.getType()).append(DELIMITER)
-                .append(modifiedDate).append(CRLF.getString());
-        }
+        additionalIdentifiers.stream()
+            .filter(isNotHandleIdentifier())
+            .forEach(additionalIdentifier ->
+                         stringBuilder.append(publicationUri).append(DELIMITER)
+                             .append(publicationStatus).append(DELIMITER)
+                             .append(identifier).append(DELIMITER)
+                             .append(additionalIdentifier.getSourceName()).append(DELIMITER)
+                             .append(additionalIdentifier.getValue()).append(DELIMITER)
+                             .append(additionalIdentifier.getType()).append(DELIMITER)
+                             .append(modifiedDate).append(CRLF.getString()));
         return stringBuilder.toString();
+    }
+
+    private static Predicate<SampleAdditionalIdentifier> isNotHandleIdentifier() {
+        return additionalIdentifier -> additionalIdentifier.getType().equals("HandleIdentifier");
     }
 
     public String getExpectedPublicationResponse() {

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -195,6 +195,7 @@ public class SamplePublication {
                 .append(identifier).append(DELIMITER)
                 .append(additionalIdentifier.getSourceName()).append(DELIMITER)
                 .append(additionalIdentifier.getValue()).append(DELIMITER)
+                .append(additionalIdentifier.getType()).append(DELIMITER)
                 .append(modifiedDate).append(CRLF.getString());
         }
         return stringBuilder.toString();

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -71,6 +71,10 @@ public class SamplePublication {
                    .collect(Collectors.toSet());
     }
 
+    public List<SampleAdditionalIdentifier> getAdditionalIdentifiers() {
+        return additionalIdentifiers;
+    }
+
     public SamplePublication withModifiedDate(Instant modifiedDate) {
         this.modifiedDate = modifiedDate;
         return this;

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/generator/publication/SamplePublication.java
@@ -22,6 +22,7 @@ public class SamplePublication {
     private SampleChannel channel;
     private List<SampleContributor> contributors;
     private List<SampleFunding> fundings;
+    private List<SampleAdditionalIdentifier> additionalIdentifiers;
     private String publicationUri;
     private String publicationStatus;
 
@@ -120,6 +121,11 @@ public class SamplePublication {
         return this;
     }
 
+    public SamplePublication withAdditionalIdentifiers(List<SampleAdditionalIdentifier> additionalIdentifiers) {
+        this.additionalIdentifiers = additionalIdentifiers;
+        return this;
+    }
+
     public String getPublicationStatus() {
         return publicationStatus;
     }
@@ -179,12 +185,12 @@ public class SamplePublication {
 
     public String getExpectedIdentifierResponse() {
         var stringBuilder = new StringBuilder();
-        for (SampleFunding funding : fundings) {
+        for (SampleAdditionalIdentifier additionalIdentifier : additionalIdentifiers) {
             stringBuilder.append(publicationUri).append(DELIMITER)
                 .append(publicationStatus).append(DELIMITER)
                 .append(identifier).append(DELIMITER)
-                .append(funding.getFundingSource()).append(DELIMITER)
-                .append(nonNull(funding.getId()) ? funding.getId() : EMPTY_STRING).append(DELIMITER)
+                .append(additionalIdentifier.getSourceName()).append(DELIMITER)
+                .append(additionalIdentifier.getValue()).append(DELIMITER)
                 .append(modifiedDate).append(CRLF.getString());
         }
         return stringBuilder.toString();

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
@@ -266,11 +266,9 @@ public record PublicationIndexDocument(String type,
                                         String value,
                                         String type) {
 
-        private static final String TYPE = "AdditionalIdentifier";
-
         public static AdditionalIdentifier from(SampleAdditionalIdentifier additionalIdentifier) {
             return new AdditionalIdentifier(additionalIdentifier.getSourceName(), additionalIdentifier.getValue(),
-                                            TYPE);
+                                            additionalIdentifier.getType());
         }
     }
 }

--- a/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
+++ b/testing-utils/src/main/java/no/sikt/nva/data/report/testing/utils/model/PublicationIndexDocument.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import no.sikt.nva.data.report.testing.utils.generator.publication.SampleAdditionalIdentifier;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleContributor;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleFunding;
 import no.sikt.nva.data.report.testing.utils.generator.publication.SampleIdentity;
@@ -24,6 +25,7 @@ public record PublicationIndexDocument(String type,
                                        String modifiedDate,
                                        String status,
                                        List<Funding> fundings,
+                                       List<AdditionalIdentifier> additionalIdentifiers,
                                        List<TestOrganization> topLevelOrganizations) implements JsonSerializable {
 
     public static final String EN = "en";
@@ -40,6 +42,7 @@ public record PublicationIndexDocument(String type,
             publication.getModifiedDate().toString(),
             publication.getPublicationStatus(),
             publication.getFundings().stream().map(Funding::from).toList(),
+            publication.getAdditionalIdentifiers().stream().map(AdditionalIdentifier::from).toList(),
             generateTopLevelOrganizations(publication)
         );
     }
@@ -256,6 +259,18 @@ public record PublicationIndexDocument(String type,
                     Map.of(EN, sampleFunding.getName())
                 );
             }
+        }
+    }
+
+    private record AdditionalIdentifier(String sourceName,
+                                        String value,
+                                        String type) {
+
+        private static final String TYPE = "AdditionalIdentifier";
+
+        public static AdditionalIdentifier from(SampleAdditionalIdentifier additionalIdentifier) {
+            return new AdditionalIdentifier(additionalIdentifier.getSourceName(), additionalIdentifier.getValue(),
+                                            TYPE);
         }
     }
 }


### PR DESCRIPTION
Update identifier report:
- Add additional identifiers
- Remove fundings, these are exported via [funding report](https://github.com/BIBSYSDEV/nva-data-report-api/blob/main/documentation/fundingReport.md)

@ketilaa: @torbjokv mentioned that the "main handle" not necessarily is available in additionalIdentifiers, but on the publication root level. Do you know if this is relevant for data export? Should we exclude `additionalIdentifiers` with `type` `HandleIdentifier` to avoid confusion?