### PR TITLE
All reports: Escape line seperators

### DIFF
--- a/data-report-commons/build.gradle
+++ b/data-report-commons/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation libs.aws.sdk2.eventbridge
     implementation libs.aws.sdk2.s3
     implementation libs.aws.sdk2.urlconnection
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.12.0'
     testImplementation(libs.nva.testutils) {
         exclude group: 'org.wiremock', module: 'wiremock'
     }

--- a/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
+++ b/data-report-commons/src/main/java/commons/formatter/CsvFormatter.java
@@ -12,6 +12,7 @@ import nva.commons.core.JacocoGenerated;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Literal;
@@ -24,6 +25,7 @@ public final class CsvFormatter implements ResponseFormatter {
     private static final String TYPE_INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
     private static final String TYPE_DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
     private static final CSVFormat CSV_FORMAT = CSVFormat.Builder.create()
+                                                    .setEscape('\\')
                                                     .setQuoteMode(QuoteMode.MINIMAL)
                                                     .build();
 
@@ -63,7 +65,7 @@ public final class CsvFormatter implements ResponseFormatter {
         } else if (isIntegerLiteral(rdfNode)) {
             rowData.add(String.valueOf(rdfNode.asLiteral().getInt()));
         } else {
-            rowData.add(rdfNode.toString());
+            rowData.add(StringEscapeUtils.escapeJava(rdfNode.toString()));
         }
     }
 

--- a/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
+++ b/data-report-commons/src/test/java/commons/formatter/CsvFormatterTest.java
@@ -3,6 +3,7 @@ package commons.formatter;
 import static org.apache.commons.io.StandardLineSeparator.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import nva.commons.core.ioutils.IoUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
@@ -29,10 +30,10 @@ class CsvFormatterTest {
     }
 
     @Test
-    void shouldQuoteNewLineValues() {
+    void shouldQuoteAndEscapeNewLineValues() {
         var model = ModelFactory.createDefaultModel();
         var inputWithNewLine = "<http://example.org/subject> <http://example.org/predicate> "
-                               + "\"value\\r\\nwith\\r\\nnewLine\" .";
+                               + "\"value\\r\\nwith\\r\\nnewLine\".";
         RDFDataMgr.read(model, IoUtils.stringToStream(inputWithNewLine), Lang.NTRIPLES);
         var query = "SELECT * WHERE { ?s ?p ?o }";
         try (var queryExecution = QueryExecutionFactory.create(query, model)) {
@@ -40,7 +41,10 @@ class CsvFormatterTest {
             var actual = new CsvFormatter().format(resultSet);
             var expected = "s,p,o"
                            + CRLF.getString()
-                           + "http://example.org/subject,http://example.org/predicate,\"value\r\nwith\r\nnewLine\""
+                           + "http://example.org/subject,http://example.org/predicate,"
+                           + "\""
+                           + StringEscapeUtils.escapeJava("value\\r\\nwith\\r\\nnewLine")
+                           + "\""
                            + CRLF.getString();
             assertEquals(expected, actual);
         }


### PR DESCRIPTION
Even though string containing special characters are quoted, data warehouse is still not able to consume strings with line seperators. Example: _" \r\nVernehelgener mot pest i Norge i senmiddelalderen"_ (https://dev.nva.sikt.no/registration/019055152ee5-e32d4020-ece8-4afd-a42c-791a2b2c9a31)

Using [org.apache.commons.text](https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/package-summary.html) `StringEscapeUtils` `escapeJava()`-method and `CSVFormat.setEscape('\\') `to escape these.

`StringEscapeUtils.escapeJava()`:
Escapes the characters in a String using Java String rules. Deals correctly with quotes and control-chars (tab, backslash, cr, ff, etc.)
Example:
 input string: `He didn't say, "Stop!"`
 output string: `He didn't say, \"Stop!\"`